### PR TITLE
Make Science Great Again:TM:

### DIFF
--- a/Content.Shared/Xenoarchaeology/Artifact/Components/XenoArtifactNodeComponent.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/Components/XenoArtifactNodeComponent.cs
@@ -64,7 +64,7 @@ public sealed partial class XenoArtifactNodeComponent : Component
     /// The amount of points a node is worth with no scaling
     /// </summary>
     [DataField, AutoNetworkedField]
-    public float BasePointValue = 1000; // Frontier: 4000<1000
+    public float BasePointValue = 2143; // Aurora: 1000->s2143 # Base Value of 3000 for depth 1
 
     /// <summary>
     /// Amount of points available currently for extracting.

--- a/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.Node.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.Node.cs
@@ -404,7 +404,7 @@ public abstract partial class SharedXenoArtifactSystem
             : 1f + durabilityEffect;
 
         var predecessorNodes = GetPredecessorNodes((artifact, artifact), node);
-        nodeComponent.ResearchValue = (int)(Math.Pow(1.4, Math.Pow(predecessorNodes.Count + 1, 1.2f)) * nodeComponent.BasePointValue * durabilityMultiplier); // Frontier: add one to count, 1.25<1.4, 1.5<1.2
+        nodeComponent.ResearchValue = (int)(Math.Pow(1.4, Math.Pow(predecessorNodes.Count + 1, 1.3f)) * nodeComponent.BasePointValue * durabilityMultiplier); // Aurora: 1.4^(x+1)^1.2 * 1000 -> 1.4^(x+1)^1.3 * 2143 : Expected increase of 3x on average for a full artifact.
         // Frontier: remove value from using artifexium, different value sets
         if (node.Comp.ArtifexiumUsed)
             nodeComponent.ResearchValue = (int)Math.Pow(nodeComponent.ResearchValue - 700, 0.9);

--- a/Content.Shared/Xenoarchaeology/Equipment/Components/ArtifactCrusherComponent.cs
+++ b/Content.Shared/Xenoarchaeology/Equipment/Components/ArtifactCrusherComponent.cs
@@ -52,13 +52,13 @@ public sealed partial class ArtifactCrusherComponent : Component
     /// The minimum amount of fragments spawned.
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
-    public int MinFragments = 2;
+    public int MinFragments = 1; // Aurora: 2->1
 
     /// <summary>
     /// The maximum amount of fragments spawned, non-inclusive.
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
-    public int MaxFragments = 5;
+    public int MaxFragments = 3; // Aurora: 5->3
 
     /// <summary>
     /// The material for the fragments.

--- a/Resources/Prototypes/Recipes/Crafting/Graphs/artifact.yml
+++ b/Resources/Prototypes/Recipes/Crafting/Graphs/artifact.yml
@@ -7,7 +7,7 @@
     - to: done
       steps:
       - material: ArtifactFragment
-        amount: 10 # Frontier: 4<10
+        amount: 4 # Aurora: 10->4
         doAfter: 5
   - node: done
     entity: ComplexXenoArtifactItem


### PR DESCRIPTION
## About the PR
Increased the value of artifacts by approximately 3x for fully completing (complex math below)
Reduced the number of artifact fragments needed to make a full artifact back down to 4 (from 10)
Reduced the output of fragments from crushing artifacts from 2-4 to 1-2 (1.33 recycled artifacts per new artifact to 2.66)

## Why / Balance
Frontiers changes to XenoArch gutted the value of artifacts, bringing the expected  value per full artifact down from ~140k RP to ~35K. This PR pushes it back up to ~93k per full artifact.

They also massive increased the amount of fragments needed to produce a fully artifact to 10, from 4. We reverted that change since it impacted mining far more than it solved the problem of the artifact crusher being too efficient.

Speaking of, we brought down the number of artifact fragments from crushing an artifact by half, since before you could almost get a 1:1 return on recycling an artifact to getting a new one.

Heres our math, data taken from sampling 10 random artifacts.
![image](https://github.com/user-attachments/assets/9ca3969a-441b-4f02-86d0-4b363c47b1b1)


## Technical details
Just number changes

## How to test
Boot up test branch
Spawn in artifact fragments
Craft an artifact.
Do some science with it.
Crush the artifact

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.

**Changelog**
:cl:
- tweak: Artifacts are now worth approximately 3x more when fully researched.
- tweak: The number of fragments needed to make a full artifact has been brought back down to 4
- tweak: The artifact crusher return has been reduced to 1-2 fragments per artifact recycled.

