### PR TITLE
Hide whispers from ghosts in WhisperCommand

### DIFF
--- a/Content.Server/Chat/Commands/WhisperCommand.cs
+++ b/Content.Server/Chat/Commands/WhisperCommand.cs
@@ -37,7 +37,8 @@ namespace Content.Server.Chat.Commands
                 return;
 
             IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<ChatSystem>()
-                .TrySendInGameICMessage(playerEntity, message, InGameICChatType.Whisper, ChatTransmitRange.Normal, false, shell, player);
+                // ChatTransmitRange.Normal < ChatTransmitRange.NoGhosts | Should hide whispers from ghosts | Aurora
+                .TrySendInGameICMessage(playerEntity, message, InGameICChatType.Whisper, ChatTransmitRange.NoGhosts, false, shell, player);
         }
     }
 }


### PR DESCRIPTION
Changed the transmit range for whispers from Normal to NoGhosts to prevent ghosts from seeing whispered messages. This improves privacy for in-game whisper communication. Needs live testing on account of the nature of the change.