### PR TITLE
Vault Tweaks

### DIFF
--- a/Resources/Prototypes/_NF/Events/nf_bluespace_grids_events.yml
+++ b/Resources/Prototypes/_NF/Events/nf_bluespace_grids_events.yml
@@ -13,6 +13,8 @@
     duration: 1350
     maxDuration: 1560
     reoccurrenceDelay: 360 # 6 hours
+    requiredJobs:
+      Sheriff: 1
   - type: BluespaceErrorRule
     groups:
       grid: !type:GridSpawnGroup


### PR DESCRIPTION
Goes the way of upstream and makes vaults pay to every station account and removes the comissioner requirement on them as well