### PR TITLE
Increase medical bounty rewards and enable gas extraction

### DIFF
--- a/Content.Shared/_NF/CCVar/NFCCVars.cs
+++ b/Content.Shared/_NF/CCVar/NFCCVars.cs
@@ -233,7 +233,7 @@ public sealed class NFCCVars
     ///     If true, allows map extraction (scrubbing a planet's atmosphere).
     /// </summary>
     public static readonly CVarDef<bool> AllowMapGasExtraction =
-        CVarDef.Create("nf14.atmos.allow_map_gas_extraction", false, CVar.SERVER | CVar.REPLICATED);
+        CVarDef.Create("nf14.atmos.allow_map_gas_extraction", true, CVar.SERVER | CVar.REPLICATED);
 
     /*
      * Audio

--- a/Resources/Prototypes/_NF/Catalog/Bounties/medical_bounties.yml
+++ b/Resources/Prototypes/_NF/Catalog/Bounties/medical_bounties.yml
@@ -5,14 +5,14 @@
     Blunt:
       min: 150
       max: 400
-      value: 10
-      penalty: 10
+      value: 30
+      penalty: 30
     Asphyxiation:
       min: 50
       max: 200
-      value: 10
-      penalty: 10
-  baseReward: 2000 # 4K-8K
+      value: 30
+      penalty: 30
+  baseReward: 2000 # 8K-20K
 
 - type: medicalBounty
   id: MurderedPierce
@@ -20,14 +20,14 @@
     Piercing:
       min: 150
       max: 400
-      value: 10
-      penalty: 10
+      value: 30
+      penalty: 30
     Bloodloss:
       min: 50
       max: 200
-      value: 10
-      penalty: 10
-  baseReward: 2000 # 4K-8K
+      value: 30
+      penalty: 30
+  baseReward: 2000 # 8K-20K
 
 - type: medicalBounty
   id: MurderedSlash
@@ -35,14 +35,14 @@
     Slash:
       min: 150
       max: 400
-      value: 10
-      penalty: 10
+      value: 30
+      penalty: 30
     Bloodloss:
       min: 50
       max: 200
-      value: 10
-      penalty: 10
-  baseReward: 2000 # 4K-8K
+      value: 30
+      penalty: 30
+  baseReward: 2000 # 8K-20K
 
 - type: medicalBounty
   id: MildBruteMix
@@ -50,24 +50,24 @@
     Blunt:
       min: 75
       max: 150
-      value: 10
-      penalty: 10
+      value: 30
+      penalty: 30
     Piercing:
       min: 75
       max: 150
-      value: 10
-      penalty: 10
+      value: 30
+      penalty: 30
     Slash:
       min: 75
       max: 150
-      value: 10
-      penalty: 10
+      value: 30
+      penalty: 30
     Bloodloss:
       min: 75
       max: 150
-      value: 10
-      penalty: 10
-  baseReward: 2000 # 5K-8K
+      value: 30
+      penalty: 30
+  baseReward: 1000 # 10K-20K
 
 - type: medicalBounty
   id: Suffocated
@@ -75,14 +75,14 @@
     Asphyxiation:
       min: 150
       max: 400
-      value: 10
-      penalty: 10
+      value: 20
+      penalty: 20
     Bloodloss:
       min: 50
       max: 200
-      value: 10
-      penalty: 10
-  baseReward: 2000 # 4K-8K
+      value: 20
+      penalty: 20
+  baseReward: 2000 # 2K-10K
 
 - type: medicalBounty
   id: PlasmaFire
@@ -100,24 +100,24 @@
     Blunt:
       min: 50
       max: 100
-      value: 10
-      penalty: 10
+      value: 30
+      penalty: 30
     Piercing:
       min: 50
       max: 100
-      value: 10
-      penalty: 10
+      value: 30
+      penalty: 30
     Slash:
       min: 50
       max: 100
-      value: 10
-      penalty: 10
+      value: 30
+      penalty: 30
     Cold:
       min: 600
       max: 2000
       value: 10
       penalty: 10
-  baseReward: 1000 # 8500-24K
+  baseReward: 1000 # 11.5k - 33K
 
 - type: medicalBounty
   id: MildBurnMix
@@ -125,24 +125,24 @@
     Heat:
       min: 50
       max: 150
-      value: 10
-      penalty: 10
+      value: 30
+      penalty: 30
     Cold:
       min: 50
       max: 150
-      value: 10
-      penalty: 10
+      value: 30
+      penalty: 30
     Shock:
       min: 50
       max: 150
-      value: 10
-      penalty: 10
+      value: 30
+      penalty: 30
     Caustic:
       min: 50
       max: 150
-      value: 10
-      penalty: 10
-  baseReward: 2000 # 4K-8K
+      value: 30
+      penalty: 30
+  baseReward: 2000 # 8K-20K
 
 - type: medicalBounty
   id: Insuls
@@ -150,14 +150,14 @@
     Heat:
       min: 200
       max: 400
-      value: 10
-      penalty: 10
+      value: 15
+      penalty: 15
     Shock:
       min: 400
       max: 600
-      value: 10
-      penalty: 10
-  baseReward: 1500 # 7500-11500
+      value: 15
+      penalty: 15
+  baseReward: 1500 # 10.5k - 16.5k
 
 - type: medicalBounty
   id: AcidSlimes
@@ -257,7 +257,7 @@
       max: 140
       value: 25
       penalty: 25
-  baseReward: 2000 # 5500-9500
+  baseReward: 4500 # 5500-9500
 
 - type: medicalBounty
   id: DeliciousUranium


### PR DESCRIPTION


## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Raised the value and penalty amounts for most medical bounties and updated base rewards to provide higher payouts. Also enabled map gas extraction by default in NFCCVars.


## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Medical mains have hard margins on their per shift profit, limiting their ability to engage in fun side activities and player driven narratives.
Planetary gas mining is fine, so long as the players aren't abusing bugs.

## Technical details
<!-- Summary of code changes for easier review. -->
change to ccvar under NF subdirectory, allowing planetary gas extraction.
YML edits to the medical bounty prototypes

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
Spawn medical pod, or find one, use scanner to appreciate that most bounties now pay out a significantly higher amount.

Go on expedition, set up scrubber network, draw atmosphere into container, observe mols fill container.



**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Gas extraction on planets
- tweak: Medical pod bounty value
