### PR TITLE
UIV's as small fleets ( i did it right this time)

### DIFF
--- a/Resources/Locale/en-US/_NF/bluespace-events/events.ftl
+++ b/Resources/Locale/en-US/_NF/bluespace-events/events.ftl
@@ -35,9 +35,9 @@ station-event-bluespace-bloodmoon-start-announcement = Attention all available C
 station-event-bluespace-bloodmoon-warning-announcement = Remote FTL procedures initialized, five minutes until Blood Cult vessel dissipation.
 station-event-bluespace-bloodmoon-end-announcement = In compliance with Colonial FTL traffic patterns, the Blood Cult vessel has been dissipated to ensure non-collision.
 
-station-event-bluespace-generic-ftl-start-announcement = Attention all Colonial citizens and/ or immigrants! Colonial Command has detected an unidentified vessel entering the Aurora Sector illegally without IFF. As per Colonial Law, the belligerent vessel is now legal salvage for authorized personnel. Investigate with caution, Colonial Command is not liable for damages sustained or loss of life.
-station-event-bluespace-generic-ftl-warning-announcement = Remote FTL procedures initialized, five minutes until unidentified vessel dissipation.
-station-event-bluespace-generic-ftl-end-announcement = In compliance with Colonial FTL traffic patterns, the unidentified vessel has been dissipated to ensure non-collision.
+station-event-bluespace-generic-ftl-start-announcement = Attention all Colonial citizens and/ or immigrants! Colonial Command has detected a flotilla of unidentified vessels entering the Aurora Sector illegally without IFF. As per Colonial Law, the belligerent vessels are now legal salvage for authorized personnel. Investigate with caution, Colonial Command is not liable for damages sustained or loss of life.
+station-event-bluespace-generic-ftl-warning-announcement = Remote FTL procedures initialized, five minutes until unidentified vessels dissipate.
+station-event-bluespace-generic-ftl-end-announcement = In compliance with Colonial FTL traffic patterns, the unidentified vessels have been dissipated to ensure non-collision.
 
 station-event-bluespace-name-BrokenMcDelivery = McDelivery
 station-event-bluespace-name-Cave = Cave

--- a/Resources/Prototypes/_NF/Events/nf_bluespace_grids_events.yml
+++ b/Resources/Prototypes/_NF/Events/nf_bluespace_grids_events.yml
@@ -38,10 +38,7 @@
         paths:
         - /Maps/_NF/Bluespace/cache.yml
     rewardAccounts:
-      Nfsd: 0.25
-      Frontier: 0.25
-      Medical: 0.25
-      Edison: 0.25
+      Nfsd: 1.0
 
 - type: entity
   id: BluespaceVaultError
@@ -82,10 +79,7 @@
         paths:
         - /Maps/_NF/Bluespace/vault.yml
     rewardAccounts:
-      Nfsd: 0.25
-      Frontier: 0.25
-      Medical: 0.25
-      Edison: 0.25
+      Nfsd: 1.0
 
 - type: entity
   id: BluespaceVaultSmallError
@@ -127,10 +121,7 @@
         paths:
         - /Maps/_NF/Bluespace/vaultsmall.yml
     rewardAccounts:
-      Nfsd: 0.25
-      Frontier: 0.25
-      Medical: 0.25
-      Edison: 0.25
+      Nfsd: 1.0
 
 - type: entity
   id: BluespaceSyndicateFTLInterception
@@ -153,6 +144,8 @@
       grid: !type:GridSpawnGroup
         nameLoc:
         - station-event-bluespace-name-UnidentifiedVessel
+        minCount: 2
+        maxCount: 3
         minimumDistance: 1500
         maximumDistance: 2500
         addComponents:
@@ -191,6 +184,8 @@
       grid: !type:GridSpawnGroup
         nameLoc:
         - station-event-bluespace-name-UnidentifiedVessel
+        minCount: 2
+        maxCount: 3
         minimumDistance: 1500
         maximumDistance: 2500
         addComponents:
@@ -229,6 +224,8 @@
       grid: !type:GridSpawnGroup
         nameLoc:
         - station-event-bluespace-name-UnidentifiedVessel
+        minCount: 2
+        maxCount: 3
         minimumDistance: 1500
         maximumDistance: 2500
         addComponents:
@@ -287,11 +284,11 @@
   parent: BaseStationEventShortDelay
   components:
   - type: StationEvent
-    startAnnouncement: station-event-bluespace-mcargo-ftl-start-announcement # Aurora event text
+    startAnnouncement: station-event-bluespace-generic-ftl-start-announcement
     startAudio:
       path: /Audio/Misc/notice1.ogg
-    warningAnnouncement: station-event-bluespace-mcargo-ftl-warning-announcement
-    endAnnouncement: station-event-bluespace-mcargo-ftl-end-announcement
+    warningAnnouncement: station-event-bluespace-generic-ftl-warning-announcement
+    endAnnouncement: station-event-bluespace-generic-ftl-end-announcement
     earliestStart: 20
     maximumPlayers: 20
     weight: 5
@@ -338,6 +335,8 @@
       grid: !type:GridSpawnGroup
         nameLoc:
         - station-event-bluespace-name-UnidentifiedVessel
+        minCount: 2
+        maxCount: 3
         minimumDistance: 1500
         maximumDistance: 2500
         addComponents:

--- a/Resources/Prototypes/_NF/Events/nf_bluespace_grids_events.yml
+++ b/Resources/Prototypes/_NF/Events/nf_bluespace_grids_events.yml
@@ -38,7 +38,10 @@
         paths:
         - /Maps/_NF/Bluespace/cache.yml
     rewardAccounts:
-      Nfsd: 1.0
+      Nfsd: 0.25
+      Frontier: 0.25
+      Medical: 0.25
+      Edison: 0.25
 
 - type: entity
   id: BluespaceVaultError
@@ -79,7 +82,10 @@
         paths:
         - /Maps/_NF/Bluespace/vault.yml
     rewardAccounts:
-      Nfsd: 1.0
+      Nfsd: 0.25
+      Frontier: 0.25
+      Medical: 0.25
+      Edison: 0.25
 
 - type: entity
   id: BluespaceVaultSmallError
@@ -121,7 +127,10 @@
         paths:
         - /Maps/_NF/Bluespace/vaultsmall.yml
     rewardAccounts:
-      Nfsd: 1.0
+      Nfsd: 0.25
+      Frontier: 0.25
+      Medical: 0.25
+      Edison: 0.25
 
 - type: entity
   id: BluespaceSyndicateFTLInterception
@@ -144,8 +153,8 @@
       grid: !type:GridSpawnGroup
         nameLoc:
         - station-event-bluespace-name-UnidentifiedVessel
-        minCount: 2
-        maxCount: 3
+        minCount: 2 #Aurora's Song
+        maxCount: 3 #Aurora's Song
         minimumDistance: 1500
         maximumDistance: 2500
         addComponents:
@@ -184,8 +193,8 @@
       grid: !type:GridSpawnGroup
         nameLoc:
         - station-event-bluespace-name-UnidentifiedVessel
-        minCount: 2
-        maxCount: 3
+        minCount: 2 #Aurora's Song
+        maxCount: 3 #Aurora's Song
         minimumDistance: 1500
         maximumDistance: 2500
         addComponents:
@@ -224,8 +233,8 @@
       grid: !type:GridSpawnGroup
         nameLoc:
         - station-event-bluespace-name-UnidentifiedVessel
-        minCount: 2
-        maxCount: 3
+        minCount: 2 #Aurora's Song
+        maxCount: 3 #Aurora's Song
         minimumDistance: 1500
         maximumDistance: 2500
         addComponents:
@@ -335,8 +344,8 @@
       grid: !type:GridSpawnGroup
         nameLoc:
         - station-event-bluespace-name-UnidentifiedVessel
-        minCount: 2
-        maxCount: 3
+        minCount: 2 #Aurora's Song
+        maxCount: 3 #Aurora's Song
         minimumDistance: 1500
         maximumDistance: 2500
         addComponents:

--- a/Resources/Prototypes/_NF/Events/nf_bluespace_grids_events.yml
+++ b/Resources/Prototypes/_NF/Events/nf_bluespace_grids_events.yml
@@ -293,11 +293,11 @@
   parent: BaseStationEventShortDelay
   components:
   - type: StationEvent
-    startAnnouncement: station-event-bluespace-generic-ftl-start-announcement
+    startAnnouncement: station-event-bluespace-mcargo-ftl-start-announcement #Aurora event text
     startAudio:
       path: /Audio/Misc/notice1.ogg
-    warningAnnouncement: station-event-bluespace-generic-ftl-warning-announcement
-    endAnnouncement: station-event-bluespace-generic-ftl-end-announcement
+    warningAnnouncement: station-event-bluespace-mcargo-ftl-warning-announcement
+    endAnnouncement: station-event-bluespace-mcargo-ftl-end-announcement
     earliestStart: 20
     maximumPlayers: 20
     weight: 5


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Shifted UIV spawns to be in clusters of 2-3 as opposed to single microdungeons, along with editing the announcement messages to address the plurality of vessels in sector.

## Why / Balance
Single UIVs are often run either very quickly by small parties of mercs, or fought over and contested by multiple parties with infighting and nonlethal or indirect conflict- in both cases leaving not much for anyone involved, or concentrating a UIV's contents onto a single group. With multiple UIV's in one go, up to a max of three, and the time required to complete, transport, and organize finds from the vessels usually taking half of the UIV's lifetime, this ensures:

  -  More than one party gets to participate and run one of the dungeons.
  -  More SLE buyback incentive/uplink credits for SLE units.
  -  Less infighting and competition for resources, tools, combat, etc, on any given UIV.
  -  Less stress to race for and fight over a given UIV.

## Technical details
Added two lines of code to each UIV type, except the caches and vaults as those carry different weight/are an SLE-protect target. Mechanically all other UIVs in the mercenary, wizard, cultist, and syndicate types now spawn in the same cluster-density as mc'cargo derelicts, with a minimum of two vessels and a maximum of three.
## How to test

   - load box, join server
   - use "addgamerule" in console for any given "bluespace[x]" event in the listing.
   - wait for grids to load in, observe
   - cry as the rng is ten times better than anything you will get in a real shift


## Media
N/A, easier to observe by example

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
- [ ] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Changed UIV spawns, vessels now appear in groups of 2-3 scattered across the sector.