### PR TITLE
adjusted name of trait and references thereof from offensive language

### DIFF
--- a/Content.Shared/Traits/Assorted/LegsParalyzedComponent.cs
+++ b/Content.Shared/Traits/Assorted/LegsParalyzedComponent.cs
@@ -4,7 +4,7 @@ namespace Content.Shared.Traits.Assorted;
 
 /// <summary>
 /// Set player speed to zero and standing state to down, simulating leg paralysis.
-/// Used for Wheelchair bound trait.
+/// Used for Wheelchair user trait.
 /// </summary>
 [RegisterComponent, NetworkedComponent, Access(typeof(LegsParalyzedSystem))]
 public sealed partial class LegsParalyzedComponent : Component

--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -30,8 +30,8 @@ trait-pirate-accent-desc = You can't stop speaking like a pirate!
 trait-accentless-name = Accentless
 trait-accentless-desc = You don't have the accent that your species would usually have
 
-trait-wheelchair-bound-name = Wheelchair-bound
-trait-wheelchair-bound-desc = You cannot move without your wheelchair. Wheelchair included.
+trait-wheelchair-user-name = Wheelchair User
+trait-wheelchair-user-desc = You cannot move without your wheelchair. Wheelchair included.
 
 trait-frontal-lisp-name = Frontal lisp
 trait-frontal-lisp-desc = You thpeak with a lithp.

--- a/Resources/Prototypes/_NF/Traits/disabilities.yml
+++ b/Resources/Prototypes/_NF/Traits/disabilities.yml
@@ -32,9 +32,9 @@
 
 # Upstream
 - type: trait
-  id: WheelchairBound
-  name: trait-wheelchair-bound-name
-  description: trait-wheelchair-bound-desc
+  id: Wheelchair-User
+  name: trait-wheelchair-user-name
+  description: trait-wheelchair-user-desc
   category: Disabilities
   blacklist:
     components:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Changed wheelchair trait name to "Wheelchair User", changed terminology/reference in-code to avoid the prior offensive language.


## Why / Balance
See: above

## How to test
Open game, customize a urist, hover over and select trait from disabilities menu.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
- [ ] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
