### PR TITLE
Harvester atmos fix & Tweaks

### DIFF
--- a/Resources/Maps/_AS/Shuttles/Expedition/harvester.yml
+++ b/Resources/Maps/_AS/Shuttles/Expedition/harvester.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 255.1.0
   forkId: ""
   forkVersion: ""
-  time: 08/14/2025 04:09:13
-  entityCount: 769
+  time: 08/17/2025 20:36:00
+  entityCount: 770
 maps: []
 grids:
 - 1
@@ -39,11 +39,11 @@ entities:
       chunks:
         0,0:
           ind: 0,0
-          tiles: AAAAAAABAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAACAQAAAAAAAgAAAAAAAwAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAQAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAADAQAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABgAAAAAABgAAAAAAAQAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABgAAAAAABgAAAAAABwAAAAABBwAAAAACBgAAAAAABgAAAAAABgAAAAAABgAAAAAAAQAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABgAAAAAABgAAAAAACAAAAAAACAAAAAAABgAAAAAABgAAAAAABgAAAAAABgAAAAAAAQAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAAAQAAAAAAAQAAAAAABwAAAAADBwAAAAACAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABgAAAAAABgAAAAAABwAAAAACBwAAAAACBgAAAAAABgAAAAAAAQAAAAAAAQAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABgAAAAAABgAAAAAABwAAAAAABwAAAAAABgAAAAAABgAAAAAAAQAAAAAAAQAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABgAAAAAABgAAAAAABwAAAAACBwAAAAAABgAAAAAABgAAAAAACwAAAAAAAwAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAACwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAACwAAAAAACwAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAACwAAAAAACwAAAAAAAQAAAAAAAQAAAAAACwAAAAAACwAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAA
+          tiles: AQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAwAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAQAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAADAQAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABgAAAAAABgAAAAAAAQAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABgAAAAAABgAAAAAABwAAAAABBwAAAAACBgAAAAAABgAAAAAABgAAAAAABgAAAAAAAQAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABgAAAAAABgAAAAAACAAAAAAACAAAAAAABgAAAAAABgAAAAAABgAAAAAABgAAAAAAAQAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAAAQAAAAAAAQAAAAAABwAAAAADBwAAAAACAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABgAAAAAABgAAAAAABwAAAAACBwAAAAACBgAAAAAABgAAAAAAAQAAAAAAAQAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABgAAAAAABgAAAAAABwAAAAAABwAAAAAABgAAAAAABgAAAAAAAQAAAAAAAQAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABgAAAAAABgAAAAAABwAAAAACBwAAAAAABgAAAAAABgAAAAAACwAAAAAAAwAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAACwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAACwAAAAAACwAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAACwAAAAAACwAAAAAAAQAAAAAAAQAAAAAACwAAAAAACwAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAA
           version: 6
         0,-1:
           ind: 0,-1
-          tiles: AQAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAQAAAAAACAAAAAAACAAAAAAABgAAAAAAAQAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABgAAAAAABgAAAAAABgAAAAAABgAAAAAABgAAAAAABgAAAAAACAAAAAAACAAAAAAABgAAAAAAAgAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABgAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAABgAAAAAACAAAAAAACAAAAAAABgAAAAAAAwAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAACAAAAAAACAAAAAAABgAAAAAAAgAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAAAQAAAAAABQAAAAAABQAAAAABBQAAAAADBQAAAAACAQAAAAAACAAAAAAACAAAAAAABgAAAAAAAQAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAACgAAAAADCgAAAAACCgAAAAAACgAAAAAACgAAAAACCgAAAAABAQAAAAAACAAAAAAAAQAAAAAAAQAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABgAAAAAABgAAAAAABgAAAAAABgAAAAAABgAAAAAABgAAAAAABwAAAAACCAAAAAAAAQAAAAAAAQAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAACgAAAAABCgAAAAABCgAAAAADCgAAAAAACgAAAAACCgAAAAAAAQAAAAAAAAAAAAACAQAAAAAAAQAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAAAQAAAAAABQAAAAAABQAAAAADBQAAAAABBQAAAAACAQAAAAAAAQAAAAAAAgAAAAAAAQAAAAAAAwAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAQAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAAAAAAAAACAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAABAQAAAAAAAgAAAAAAAwAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAwAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAAAAAAAAADAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAACAQAAAAAAAgAAAAAAAwAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAwAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAAAAAAAAABAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAACAQAAAAAAAgAAAAAAAwAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAwAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAA
+          tiles: AQAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAQAAAAAACAAAAAAACAAAAAAABgAAAAAAAQAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABgAAAAAABgAAAAAABgAAAAAABgAAAAAABgAAAAAABgAAAAAACAAAAAAACAAAAAAABgAAAAAAAgAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABgAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAABgAAAAAACAAAAAAACAAAAAAABgAAAAAAAwAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAACAAAAAAACAAAAAAABgAAAAAAAgAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAAAQAAAAAABQAAAAAABQAAAAABBQAAAAADBQAAAAACAQAAAAAACAAAAAAACAAAAAAABgAAAAAAAQAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAACgAAAAADCgAAAAACCgAAAAAACgAAAAAACgAAAAACCgAAAAABAQAAAAAACAAAAAAAAQAAAAAAAQAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABgAAAAAABgAAAAAABgAAAAAABgAAAAAABgAAAAAABgAAAAAABwAAAAACCAAAAAAAAQAAAAAAAQAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAACgAAAAABCgAAAAABCgAAAAADCgAAAAAACgAAAAACCgAAAAAAAQAAAAAAAAAAAAACAQAAAAAAAQAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAAAQAAAAAABQAAAAAABQAAAAADBQAAAAABBQAAAAACAQAAAAAAAQAAAAAAAgAAAAAAAQAAAAAAAwAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAQAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAwAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAwAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAwAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAwAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAwAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAwAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAA
           version: 6
         -1,0:
           ind: -1,0
@@ -201,89 +201,115 @@ entities:
           0,0:
             0: 65310
           -1,0:
-            0: 19660
-            1: 2
-          0,1:
-            0: 53232
-          -1,1:
             0: 3276
-            1: 8192
+            2: 2
+            1: 16384
+          0,1:
+            1: 53232
+          -1,1:
+            1: 3276
+            2: 8192
           0,2:
-            0: 4095
+            1: 4095
           0,3:
-            1: 1
-            0: 12
+            0: 1
+            1: 12
           -1,2:
-            1: 33792
+            0: 32768
+            2: 1024
           1,0:
-            0: 49133
+            0: 16365
+            1: 32768
           1,1:
-            0: 4092
+            1: 4092
           1,2:
-            0: 819
-            1: 18432
+            1: 819
+            0: 16384
+            2: 2048
           1,3:
-            1: 2
+            0: 2
           1,-1:
             0: 52685
           2,0:
-            1: 1
+            2: 1
           2,1:
-            1: 4096
+            2: 4096
           2,-1:
-            1: 4369
+            2: 4369
           0,-4:
-            0: 4094
+            1: 4094
           -1,-4:
-            0: 65278
-            1: 256
+            1: 65278
+            2: 256
           0,-3:
-            0: 65534
+            1: 65534
           -1,-3:
-            0: 19550
+            1: 19534
+            0: 16
           0,-2:
-            0: 3598
+            1: 14
+            0: 3584
           -1,-2:
             0: 52428
-            1: 8705
+            2: 8705
           0,-1:
             0: 3598
           -1,-1:
             0: 52428
-            1: 8738
+            2: 8738
           1,-4:
-            0: 53245
+            1: 53245
           1,-3:
-            0: 49085
+            1: 49085
           1,-2:
-            0: 52685
+            1: 1
+            0: 52684
           1,-5:
-            0: 35763
+            1: 35763
           2,-4:
-            0: 12593
-            1: 512
+            1: 12593
+            2: 512
           2,-3:
-            0: 33
+            1: 1
+            0: 32
           2,-2:
-            1: 4354
+            2: 4354
           2,-5:
             0: 8704
           -1,-5:
-            0: 21952
+            0: 4352
+            1: 17600
           -1,-6:
-            1: 5248
+            2: 5248
             0: 24576
           0,-6:
-            0: 61664
+            1: 61440
+            0: 224
           0,-5:
-            0: 4095
+            1: 4095
           1,-6:
-            0: 45072
-            1: 2112
+            0: 32784
+            1: 12288
+            2: 2112
           2,-6:
             0: 4096
-            1: 8192
+            2: 8192
         uniqueMixes:
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
         - volume: 2500
           temperature: 293.15
           moles:
@@ -328,9 +354,9 @@ entities:
     - type: DeviceList
       devices:
       - 28
-      - 203
-      - 330
-      - 333
+      - 321
+      - 448
+      - 451
   - uid: 3
     components:
     - type: Transform
@@ -339,12 +365,12 @@ entities:
     - type: DeviceList
       devices:
       - 27
-      - 332
-      - 326
-      - 206
-      - 207
-      - 204
-      - 205
+      - 450
+      - 444
+      - 324
+      - 325
+      - 322
+      - 323
   - uid: 4
     components:
     - type: Transform
@@ -352,11 +378,11 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 331
+      - 449
       - 26
-      - 327
-      - 200
-      - 199
+      - 445
+      - 318
+      - 317
   - uid: 5
     components:
     - type: Transform
@@ -365,11 +391,11 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 201
-      - 202
+      - 319
+      - 320
       - 25
-      - 329
-      - 335
+      - 447
+      - 453
   - uid: 6
     components:
     - type: Transform
@@ -377,11 +403,22 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 334
-      - 328
+      - 452
+      - 446
       - 24
-      - 201
-      - 202
+      - 319
+      - 320
+  - uid: 770
+    components:
+    - type: Transform
+      pos: 6.5,3.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 21
+      - 22
+      - 20
+      - 23
 - proto: Airlock
   entities:
   - uid: 7
@@ -426,7 +463,7 @@ entities:
       pos: 7.5,-8.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -6862.4697
+      secondsUntilStateChange: -7037.591
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -474,21 +511,33 @@ entities:
     - type: Transform
       pos: 2.5,-3.5
       parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 770
   - uid: 21
     components:
     - type: Transform
       pos: 2.5,0.5
       parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 770
   - uid: 22
     components:
     - type: Transform
       pos: 2.5,-1.5
       parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 770
   - uid: 23
     components:
     - type: Transform
       pos: 2.5,-5.5
       parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 770
   - uid: 24
     components:
     - type: Transform
@@ -674,709 +723,709 @@ entities:
       parent: 1
 - proto: AtmosFixBlockerMarker
   entities:
-  - uid: 650
+  - uid: 51
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,-5.5
       parent: 1
-  - uid: 651
+  - uid: 52
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,-4.5
       parent: 1
-  - uid: 652
+  - uid: 53
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,-3.5
       parent: 1
-  - uid: 653
+  - uid: 54
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,-2.5
       parent: 1
-  - uid: 654
+  - uid: 55
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,-1.5
       parent: 1
-  - uid: 655
+  - uid: 56
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,-0.5
       parent: 1
-  - uid: 656
+  - uid: 57
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,0.5
       parent: 1
-  - uid: 657
+  - uid: 58
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,2.5
       parent: 1
-  - uid: 658
+  - uid: 59
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,1.5
       parent: 1
-  - uid: 659
+  - uid: 60
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,0.5
       parent: 1
-  - uid: 660
+  - uid: 61
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-0.5
       parent: 1
-  - uid: 661
+  - uid: 62
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-1.5
       parent: 1
-  - uid: 662
+  - uid: 63
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-2.5
       parent: 1
-  - uid: 663
+  - uid: 64
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-3.5
       parent: 1
-  - uid: 664
+  - uid: 65
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-4.5
       parent: 1
-  - uid: 665
+  - uid: 66
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-5.5
       parent: 1
-  - uid: 666
+  - uid: 67
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-7.5
       parent: 1
-  - uid: 667
+  - uid: 68
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-6.5
       parent: 1
-  - uid: 668
+  - uid: 69
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-7.5
       parent: 1
-  - uid: 669
+  - uid: 70
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-6.5
       parent: 1
-  - uid: 670
+  - uid: 71
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-5.5
       parent: 1
-  - uid: 671
+  - uid: 72
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-4.5
       parent: 1
-  - uid: 672
+  - uid: 73
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-3.5
       parent: 1
-  - uid: 673
+  - uid: 74
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-2.5
       parent: 1
-  - uid: 674
+  - uid: 75
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-1.5
       parent: 1
-  - uid: 675
+  - uid: 76
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-0.5
       parent: 1
-  - uid: 676
+  - uid: 77
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,0.5
       parent: 1
-  - uid: 677
+  - uid: 78
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,1.5
       parent: 1
-  - uid: 678
+  - uid: 79
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,2.5
       parent: 1
-  - uid: 679
+  - uid: 80
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,1.5
       parent: 1
-  - uid: 680
+  - uid: 81
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,2.5
       parent: 1
-  - uid: 681
+  - uid: 82
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,3.5
       parent: 1
-  - uid: 682
+  - uid: 83
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,2.5
       parent: 1
-  - uid: 683
+  - uid: 84
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,3.5
       parent: 1
-  - uid: 684
+  - uid: 85
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,2.5
       parent: 1
-  - uid: 685
+  - uid: 86
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,3.5
       parent: 1
-  - uid: 686
+  - uid: 87
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,2.5
       parent: 1
-  - uid: 687
+  - uid: 88
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,3.5
       parent: 1
-  - uid: 688
+  - uid: 89
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,2.5
       parent: 1
-  - uid: 689
+  - uid: 90
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,3.5
       parent: 1
-  - uid: 690
+  - uid: 91
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,3.5
       parent: 1
-  - uid: 691
+  - uid: 92
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,2.5
       parent: 1
-  - uid: 692
+  - uid: 93
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,1.5
       parent: 1
-  - uid: 693
+  - uid: 94
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,2.5
       parent: 1
-  - uid: 694
+  - uid: 95
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,1.5
       parent: 1
-  - uid: 695
+  - uid: 96
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,0.5
       parent: 1
-  - uid: 696
+  - uid: 97
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-0.5
       parent: 1
-  - uid: 697
+  - uid: 98
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-1.5
       parent: 1
-  - uid: 698
+  - uid: 99
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-2.5
       parent: 1
-  - uid: 699
+  - uid: 100
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-3.5
       parent: 1
-  - uid: 700
+  - uid: 101
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-4.5
       parent: 1
-  - uid: 701
+  - uid: 102
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-5.5
       parent: 1
-  - uid: 702
+  - uid: 103
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-6.5
       parent: 1
-  - uid: 703
+  - uid: 104
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-7.5
       parent: 1
-  - uid: 704
+  - uid: 105
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,2.5
       parent: 1
-  - uid: 705
+  - uid: 106
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,1.5
       parent: 1
-  - uid: 706
+  - uid: 107
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,0.5
       parent: 1
-  - uid: 707
+  - uid: 108
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-0.5
       parent: 1
-  - uid: 708
+  - uid: 109
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-1.5
       parent: 1
-  - uid: 709
+  - uid: 110
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-2.5
       parent: 1
-  - uid: 710
+  - uid: 111
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-3.5
       parent: 1
-  - uid: 711
+  - uid: 112
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-4.5
       parent: 1
-  - uid: 712
+  - uid: 113
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-5.5
       parent: 1
-  - uid: 713
+  - uid: 114
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-6.5
       parent: 1
-  - uid: 714
+  - uid: 115
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-7.5
       parent: 1
-  - uid: 715
+  - uid: 116
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-5.5
       parent: 1
-  - uid: 716
+  - uid: 117
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-4.5
       parent: 1
-  - uid: 717
+  - uid: 118
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-3.5
       parent: 1
-  - uid: 718
+  - uid: 119
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-2.5
       parent: 1
-  - uid: 719
+  - uid: 120
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-1.5
       parent: 1
-  - uid: 720
+  - uid: 121
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-0.5
       parent: 1
-  - uid: 721
+  - uid: 122
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,0.5
       parent: 1
-  - uid: 722
+  - uid: 123
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-5.5
       parent: 1
-  - uid: 723
+  - uid: 124
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-5.5
       parent: 1
-  - uid: 724
+  - uid: 125
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-5.5
       parent: 1
-  - uid: 725
+  - uid: 126
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-5.5
       parent: 1
-  - uid: 726
+  - uid: 127
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-3.5
       parent: 1
-  - uid: 727
+  - uid: 128
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-3.5
       parent: 1
-  - uid: 728
+  - uid: 129
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-3.5
       parent: 1
-  - uid: 729
+  - uid: 130
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-3.5
       parent: 1
-  - uid: 730
+  - uid: 131
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-1.5
       parent: 1
-  - uid: 731
+  - uid: 132
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-1.5
       parent: 1
-  - uid: 732
+  - uid: 133
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-1.5
       parent: 1
-  - uid: 733
+  - uid: 134
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-1.5
       parent: 1
-  - uid: 734
+  - uid: 135
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,0.5
       parent: 1
-  - uid: 735
+  - uid: 136
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,0.5
       parent: 1
-  - uid: 736
+  - uid: 137
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,0.5
       parent: 1
-  - uid: 737
+  - uid: 138
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,0.5
       parent: 1
-  - uid: 738
+  - uid: 139
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,7.5
       parent: 1
-  - uid: 739
+  - uid: 140
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,10.5
       parent: 1
-  - uid: 740
+  - uid: 141
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,10.5
       parent: 1
-  - uid: 741
+  - uid: 142
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,7.5
       parent: 1
-  - uid: 742
+  - uid: 143
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,-10.5
       parent: 1
-  - uid: 743
+  - uid: 144
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-10.5
       parent: 1
-  - uid: 744
+  - uid: 145
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-7.5
       parent: 1
-  - uid: 745
+  - uid: 146
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,-7.5
       parent: 1
-  - uid: 746
+  - uid: 147
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,-16.5
       parent: 1
-  - uid: 747
+  - uid: 148
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,-17.5
       parent: 1
-  - uid: 748
+  - uid: 149
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-16.5
       parent: 1
-  - uid: 749
+  - uid: 150
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-17.5
       parent: 1
-  - uid: 750
+  - uid: 151
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-20.5
       parent: 1
-  - uid: 751
+  - uid: 152
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-20.5
       parent: 1
-  - uid: 752
+  - uid: 153
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-20.5
       parent: 1
-  - uid: 753
+  - uid: 154
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-20.5
       parent: 1
-  - uid: 754
+  - uid: 155
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,-20.5
       parent: 1
-  - uid: 755
+  - uid: 156
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,-20.5
       parent: 1
-  - uid: 756
+  - uid: 157
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-21.5
       parent: 1
-  - uid: 757
+  - uid: 158
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-22.5
       parent: 1
-  - uid: 758
+  - uid: 159
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-22.5
       parent: 1
-  - uid: 759
+  - uid: 160
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-21.5
       parent: 1
-  - uid: 760
+  - uid: 161
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-22.5
       parent: 1
-  - uid: 761
+  - uid: 162
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-22.5
       parent: 1
-  - uid: 762
+  - uid: 163
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-22.5
       parent: 1
-  - uid: 763
+  - uid: 164
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-22.5
       parent: 1
-  - uid: 764
+  - uid: 165
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,11.5
       parent: 1
-  - uid: 765
+  - uid: 166
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,12.5
       parent: 1
-  - uid: 766
+  - uid: 167
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,12.5
       parent: 1
-  - uid: 767
+  - uid: 168
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1384,19 +1433,19 @@ entities:
       parent: 1
 - proto: Bed
   entities:
-  - uid: 51
+  - uid: 169
     components:
     - type: Transform
       pos: 4.5,-7.5
       parent: 1
-  - uid: 52
+  - uid: 170
     components:
     - type: Transform
       pos: 4.5,-11.5
       parent: 1
 - proto: BedsheetBlack
   entities:
-  - uid: 53
+  - uid: 171
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1404,7 +1453,7 @@ entities:
       parent: 1
 - proto: BedsheetBrown
   entities:
-  - uid: 54
+  - uid: 172
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1412,7 +1461,7 @@ entities:
       parent: 1
 - proto: BenchComfy
   entities:
-  - uid: 55
+  - uid: 173
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1420,14 +1469,14 @@ entities:
       parent: 1
 - proto: Bucket
   entities:
-  - uid: 56
+  - uid: 174
     components:
     - type: Transform
       pos: 7.684305,-17.629124
       parent: 1
 - proto: ButtonFrameCaution
   entities:
-  - uid: 57
+  - uid: 175
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1435,558 +1484,558 @@ entities:
       parent: 1
 - proto: CableApcExtension
   entities:
-  - uid: 58
+  - uid: 176
     components:
     - type: Transform
       pos: -0.5,-17.5
       parent: 1
-  - uid: 59
+  - uid: 177
     components:
     - type: Transform
       pos: 0.5,-17.5
       parent: 1
-  - uid: 60
+  - uid: 178
     components:
     - type: Transform
       pos: -1.5,-18.5
       parent: 1
-  - uid: 61
+  - uid: 179
     components:
     - type: Transform
       pos: 0.5,-18.5
       parent: 1
-  - uid: 62
+  - uid: 180
     components:
     - type: Transform
       pos: 1.5,-18.5
       parent: 1
-  - uid: 63
+  - uid: 181
     components:
     - type: Transform
       pos: 1.5,-18.5
       parent: 1
-  - uid: 64
+  - uid: 182
     components:
     - type: Transform
       pos: 1.5,-19.5
       parent: 1
-  - uid: 65
+  - uid: 183
     components:
     - type: Transform
       pos: 1.5,-20.5
       parent: 1
-  - uid: 66
+  - uid: 184
     components:
     - type: Transform
       pos: 1.5,-20.5
       parent: 1
-  - uid: 67
+  - uid: 185
     components:
     - type: Transform
       pos: 2.5,-20.5
       parent: 1
-  - uid: 68
+  - uid: 186
     components:
     - type: Transform
       pos: 3.5,-20.5
       parent: 1
-  - uid: 69
+  - uid: 187
     components:
     - type: Transform
       pos: -0.5,-17.5
       parent: 1
-  - uid: 70
+  - uid: 188
     components:
     - type: Transform
       pos: -1.5,-17.5
       parent: 1
-  - uid: 71
+  - uid: 189
     components:
     - type: Transform
       pos: -1.5,-17.5
       parent: 1
-  - uid: 72
+  - uid: 190
     components:
     - type: Transform
       pos: -1.5,-16.5
       parent: 1
-  - uid: 73
+  - uid: 191
     components:
     - type: Transform
       pos: -1.5,-15.5
       parent: 1
-  - uid: 74
+  - uid: 192
     components:
     - type: Transform
       pos: -1.5,-14.5
       parent: 1
-  - uid: 75
+  - uid: 193
     components:
     - type: Transform
       pos: -1.5,-13.5
       parent: 1
-  - uid: 76
+  - uid: 194
     components:
     - type: Transform
       pos: -1.5,-12.5
       parent: 1
-  - uid: 77
+  - uid: 195
     components:
     - type: Transform
       pos: -1.5,-11.5
       parent: 1
-  - uid: 78
+  - uid: 196
     components:
     - type: Transform
       pos: -1.5,-10.5
       parent: 1
-  - uid: 79
+  - uid: 197
     components:
     - type: Transform
       pos: -1.5,-9.5
       parent: 1
-  - uid: 80
+  - uid: 198
     components:
     - type: Transform
       pos: -1.5,-8.5
       parent: 1
-  - uid: 81
+  - uid: 199
     components:
     - type: Transform
       pos: -1.5,-7.5
       parent: 1
-  - uid: 82
+  - uid: 200
     components:
     - type: Transform
       pos: -1.5,-6.5
       parent: 1
-  - uid: 83
+  - uid: 201
     components:
     - type: Transform
       pos: -1.5,-5.5
       parent: 1
-  - uid: 84
+  - uid: 202
     components:
     - type: Transform
       pos: -1.5,-4.5
       parent: 1
-  - uid: 85
+  - uid: 203
     components:
     - type: Transform
       pos: -1.5,-3.5
       parent: 1
-  - uid: 86
+  - uid: 204
     components:
     - type: Transform
       pos: -1.5,-2.5
       parent: 1
-  - uid: 87
+  - uid: 205
     components:
     - type: Transform
       pos: -1.5,-1.5
       parent: 1
-  - uid: 88
+  - uid: 206
     components:
     - type: Transform
       pos: -1.5,-0.5
       parent: 1
-  - uid: 89
+  - uid: 207
     components:
     - type: Transform
       pos: -1.5,0.5
       parent: 1
-  - uid: 90
+  - uid: 208
     components:
     - type: Transform
       pos: -1.5,1.5
       parent: 1
-  - uid: 91
+  - uid: 209
     components:
     - type: Transform
       pos: -1.5,2.5
       parent: 1
-  - uid: 92
+  - uid: 210
     components:
     - type: Transform
       pos: -1.5,3.5
       parent: 1
-  - uid: 93
+  - uid: 211
     components:
     - type: Transform
       pos: -1.5,4.5
       parent: 1
-  - uid: 94
+  - uid: 212
     components:
     - type: Transform
       pos: -1.5,5.5
       parent: 1
-  - uid: 95
+  - uid: 213
     components:
     - type: Transform
       pos: -1.5,5.5
       parent: 1
-  - uid: 96
+  - uid: 214
     components:
     - type: Transform
       pos: -0.5,5.5
       parent: 1
-  - uid: 97
+  - uid: 215
     components:
     - type: Transform
       pos: 0.5,5.5
       parent: 1
-  - uid: 98
+  - uid: 216
     components:
     - type: Transform
       pos: 1.5,5.5
       parent: 1
-  - uid: 99
+  - uid: 217
     components:
     - type: Transform
       pos: 2.5,5.5
       parent: 1
-  - uid: 100
+  - uid: 218
     components:
     - type: Transform
       pos: 2.5,5.5
       parent: 1
-  - uid: 101
+  - uid: 219
     components:
     - type: Transform
       pos: 2.5,6.5
       parent: 1
-  - uid: 102
+  - uid: 220
     components:
     - type: Transform
       pos: 2.5,7.5
       parent: 1
-  - uid: 103
+  - uid: 221
     components:
     - type: Transform
       pos: 2.5,8.5
       parent: 1
-  - uid: 104
+  - uid: 222
     components:
     - type: Transform
       pos: 2.5,9.5
       parent: 1
-  - uid: 105
+  - uid: 223
     components:
     - type: Transform
       pos: 2.5,10.5
       parent: 1
-  - uid: 106
+  - uid: 224
     components:
     - type: Transform
       pos: 1.5,10.5
       parent: 1
-  - uid: 107
+  - uid: 225
     components:
     - type: Transform
       pos: 3.5,10.5
       parent: 1
-  - uid: 108
+  - uid: 226
     components:
     - type: Transform
       pos: 4.5,10.5
       parent: 1
-  - uid: 109
+  - uid: 227
     components:
     - type: Transform
       pos: 5.5,10.5
       parent: 1
-  - uid: 110
+  - uid: 228
     components:
     - type: Transform
       pos: 0.5,10.5
       parent: 1
-  - uid: 111
+  - uid: 229
     components:
     - type: Transform
       pos: 7.5,-14.5
       parent: 1
-  - uid: 112
+  - uid: 230
     components:
     - type: Transform
       pos: 4.5,5.5
       parent: 1
-  - uid: 113
+  - uid: 231
     components:
     - type: Transform
       pos: 5.5,5.5
       parent: 1
-  - uid: 114
+  - uid: 232
     components:
     - type: Transform
       pos: 6.5,5.5
       parent: 1
-  - uid: 115
+  - uid: 233
     components:
     - type: Transform
       pos: 7.5,5.5
       parent: 1
-  - uid: 116
+  - uid: 234
     components:
     - type: Transform
       pos: -0.5,-13.5
       parent: 1
-  - uid: 117
+  - uid: 235
     components:
     - type: Transform
       pos: 0.5,-13.5
       parent: 1
-  - uid: 118
+  - uid: 236
     components:
     - type: Transform
       pos: 1.5,-13.5
       parent: 1
-  - uid: 119
+  - uid: 237
     components:
     - type: Transform
       pos: 2.5,-13.5
       parent: 1
-  - uid: 120
+  - uid: 238
     components:
     - type: Transform
       pos: 3.5,-13.5
       parent: 1
-  - uid: 121
+  - uid: 239
     components:
     - type: Transform
       pos: 4.5,-13.5
       parent: 1
-  - uid: 122
+  - uid: 240
     components:
     - type: Transform
       pos: 5.5,-13.5
       parent: 1
-  - uid: 123
+  - uid: 241
     components:
     - type: Transform
       pos: 6.5,-13.5
       parent: 1
-  - uid: 124
+  - uid: 242
     components:
     - type: Transform
       pos: 7.5,-13.5
       parent: 1
-  - uid: 125
+  - uid: 243
     components:
     - type: Transform
       pos: 7.5,-13.5
       parent: 1
-  - uid: 126
+  - uid: 244
     components:
     - type: Transform
       pos: 7.5,-12.5
       parent: 1
-  - uid: 127
+  - uid: 245
     components:
     - type: Transform
       pos: 7.5,-11.5
       parent: 1
-  - uid: 128
+  - uid: 246
     components:
     - type: Transform
       pos: 7.5,-10.5
       parent: 1
-  - uid: 129
+  - uid: 247
     components:
     - type: Transform
       pos: 7.5,-9.5
       parent: 1
-  - uid: 130
+  - uid: 248
     components:
     - type: Transform
       pos: 7.5,-8.5
       parent: 1
-  - uid: 131
+  - uid: 249
     components:
     - type: Transform
       pos: 7.5,-7.5
       parent: 1
-  - uid: 132
+  - uid: 250
     components:
     - type: Transform
       pos: 7.5,-6.5
       parent: 1
-  - uid: 133
+  - uid: 251
     components:
     - type: Transform
       pos: 7.5,-5.5
       parent: 1
-  - uid: 134
+  - uid: 252
     components:
     - type: Transform
       pos: 7.5,-4.5
       parent: 1
-  - uid: 135
+  - uid: 253
     components:
     - type: Transform
       pos: 7.5,-3.5
       parent: 1
-  - uid: 136
+  - uid: 254
     components:
     - type: Transform
       pos: 7.5,-2.5
       parent: 1
-  - uid: 137
+  - uid: 255
     components:
     - type: Transform
       pos: 7.5,-1.5
       parent: 1
-  - uid: 138
+  - uid: 256
     components:
     - type: Transform
       pos: 7.5,-0.5
       parent: 1
-  - uid: 139
+  - uid: 257
     components:
     - type: Transform
       pos: 7.5,1.5
       parent: 1
-  - uid: 140
+  - uid: 258
     components:
     - type: Transform
       pos: 7.5,2.5
       parent: 1
-  - uid: 141
+  - uid: 259
     components:
     - type: Transform
       pos: 7.5,3.5
       parent: 1
-  - uid: 142
+  - uid: 260
     components:
     - type: Transform
       pos: 7.5,4.5
       parent: 1
-  - uid: 143
+  - uid: 261
     components:
     - type: Transform
       pos: 7.5,0.5
       parent: 1
-  - uid: 144
+  - uid: 262
     components:
     - type: Transform
       pos: 7.5,-15.5
       parent: 1
-  - uid: 145
+  - uid: 263
     components:
     - type: Transform
       pos: 7.5,-16.5
       parent: 1
-  - uid: 146
+  - uid: 264
     components:
     - type: Transform
       pos: 7.5,-17.5
       parent: 1
-  - uid: 147
+  - uid: 265
     components:
     - type: Transform
       pos: 7.5,-18.5
       parent: 1
-  - uid: 148
+  - uid: 266
     components:
     - type: Transform
       pos: 6.5,-9.5
       parent: 1
-  - uid: 149
+  - uid: 267
     components:
     - type: Transform
       pos: 5.5,-9.5
       parent: 1
-  - uid: 150
+  - uid: 268
     components:
     - type: Transform
       pos: 4.5,-9.5
       parent: 1
-  - uid: 151
+  - uid: 269
     components:
     - type: Transform
       pos: 3.5,-9.5
       parent: 1
-  - uid: 152
+  - uid: 270
     components:
     - type: Transform
       pos: 2.5,-9.5
       parent: 1
-  - uid: 153
+  - uid: 271
     components:
     - type: Transform
       pos: 1.5,-9.5
       parent: 1
-  - uid: 154
+  - uid: 272
     components:
     - type: Transform
       pos: -2.5,-13.5
       parent: 1
-  - uid: 155
+  - uid: 273
     components:
     - type: Transform
       pos: 8.5,-13.5
       parent: 1
-  - uid: 156
+  - uid: 274
     components:
     - type: Transform
       pos: 4.5,-20.5
       parent: 1
 - proto: CableHV
   entities:
-  - uid: 157
+  - uid: 275
     components:
     - type: Transform
       pos: 0.5,-17.5
       parent: 1
-  - uid: 158
+  - uid: 276
     components:
     - type: Transform
       pos: 1.5,-17.5
       parent: 1
-  - uid: 159
+  - uid: 277
     components:
     - type: Transform
       pos: 2.5,-17.5
       parent: 1
-  - uid: 160
+  - uid: 278
     components:
     - type: Transform
       pos: 2.5,-18.5
       parent: 1
-  - uid: 161
+  - uid: 279
     components:
     - type: Transform
       pos: 3.5,-18.5
       parent: 1
-  - uid: 162
+  - uid: 280
     components:
     - type: Transform
       pos: 4.5,-18.5
       parent: 1
-  - uid: 163
+  - uid: 281
     components:
     - type: Transform
       pos: 5.5,-18.5
       parent: 1
-  - uid: 164
+  - uid: 282
     components:
     - type: Transform
       pos: 2.5,-19.5
       parent: 1
 - proto: CableMV
   entities:
-  - uid: 165
+  - uid: 283
     components:
     - type: Transform
       pos: 0.5,-17.5
       parent: 1
-  - uid: 166
+  - uid: 284
     components:
     - type: Transform
       pos: -0.5,-17.5
       parent: 1
 - proto: CableTerminal
   entities:
-  - uid: 167
+  - uid: 285
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1994,13 +2043,13 @@ entities:
       parent: 1
 - proto: ChairOfficeDark
   entities:
-  - uid: 168
+  - uid: 286
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.6897216,-8.122806
       parent: 1
-  - uid: 169
+  - uid: 287
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2008,13 +2057,13 @@ entities:
       parent: 1
 - proto: ChairPilotSeat
   entities:
-  - uid: 170
+  - uid: 288
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,9.5
       parent: 1
-  - uid: 171
+  - uid: 289
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2022,7 +2071,7 @@ entities:
       parent: 1
 - proto: ClosetWallFireFilledRandom
   entities:
-  - uid: 172
+  - uid: 290
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2030,7 +2079,7 @@ entities:
       parent: 1
 - proto: ClosetWallO2Filled
   entities:
-  - uid: 173
+  - uid: 291
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2038,7 +2087,7 @@ entities:
       parent: 1
 - proto: ComputerAtmosMonitoring
   entities:
-  - uid: 174
+  - uid: 292
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2046,27 +2095,27 @@ entities:
       parent: 1
 - proto: ComputerPowerMonitoring
   entities:
-  - uid: 175
+  - uid: 293
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-19.5
       parent: 1
-  - uid: 176
+  - uid: 294
     components:
     - type: Transform
       pos: 3.5,10.5
       parent: 1
 - proto: ComputerRadar
   entities:
-  - uid: 177
+  - uid: 295
     components:
     - type: Transform
       pos: 2.5,10.5
       parent: 1
 - proto: ComputerStationRecords
   entities:
-  - uid: 178
+  - uid: 296
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2074,34 +2123,34 @@ entities:
       parent: 1
 - proto: ComputerTabletopSalvageExpedition
   entities:
-  - uid: 179
+  - uid: 297
     components:
     - type: Transform
       pos: 1.5,10.5
       parent: 1
 - proto: ComputerTabletopShuttle
   entities:
-  - uid: 180
+  - uid: 298
     components:
     - type: Transform
       pos: 4.5,10.5
       parent: 1
 - proto: CrateMaterialsBasicFilled
   entities:
-  - uid: 181
+  - uid: 299
     components:
     - type: Transform
       pos: -0.5,-15.5
       parent: 1
 - proto: CurtainsOrangeOpen
   entities:
-  - uid: 182
+  - uid: 300
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-11.5
       parent: 1
-  - uid: 183
+  - uid: 301
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2109,76 +2158,76 @@ entities:
       parent: 1
 - proto: DrinkMugMetal
   entities:
-  - uid: 184
+  - uid: 302
     components:
     - type: Transform
       pos: 1.9176154,-11.340929
       parent: 1
 - proto: EmergencyLight
   entities:
-  - uid: 185
+  - uid: 303
     components:
     - type: Transform
       pos: 4.5,6.5
       parent: 1
-  - uid: 186
+  - uid: 304
     components:
     - type: Transform
       pos: 1.5,6.5
       parent: 1
-  - uid: 187
+  - uid: 305
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,8.5
       parent: 1
-  - uid: 188
+  - uid: 306
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,8.5
       parent: 1
-  - uid: 189
+  - uid: 307
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,-6.5
       parent: 1
-  - uid: 190
+  - uid: 308
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,-6.5
       parent: 1
-  - uid: 191
+  - uid: 309
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,-12.5
       parent: 1
-  - uid: 192
+  - uid: 310
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,-12.5
       parent: 1
-  - uid: 193
+  - uid: 311
     components:
     - type: Transform
       pos: 0.5,-17.5
       parent: 1
-  - uid: 194
+  - uid: 312
     components:
     - type: Transform
       pos: 5.5,-17.5
       parent: 1
-  - uid: 195
+  - uid: 313
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,-0.5
       parent: 1
-  - uid: 196
+  - uid: 314
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2186,21 +2235,21 @@ entities:
       parent: 1
 - proto: EngineeringTechFab
   entities:
-  - uid: 197
+  - uid: 315
     components:
     - type: Transform
       pos: 3.5,-15.5
       parent: 1
 - proto: FaxMachineShip
   entities:
-  - uid: 198
+  - uid: 316
     components:
     - type: Transform
       pos: 2.5,-11.5
       parent: 1
 - proto: Firelock
   entities:
-  - uid: 199
+  - uid: 317
     components:
     - type: Transform
       pos: -0.5,-9.5
@@ -2208,7 +2257,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 4
-  - uid: 200
+  - uid: 318
     components:
     - type: Transform
       pos: 6.5,-9.5
@@ -2216,7 +2265,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 4
-  - uid: 201
+  - uid: 319
     components:
     - type: Transform
       pos: 3.5,7.5
@@ -2225,7 +2274,7 @@ entities:
       deviceLists:
       - 6
       - 5
-  - uid: 202
+  - uid: 320
     components:
     - type: Transform
       pos: 2.5,7.5
@@ -2234,7 +2283,7 @@ entities:
       deviceLists:
       - 6
       - 5
-  - uid: 203
+  - uid: 321
     components:
     - type: Transform
       pos: -0.5,-18.5
@@ -2244,7 +2293,7 @@ entities:
       - 2
 - proto: FirelockEdge
   entities:
-  - uid: 204
+  - uid: 322
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2253,7 +2302,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 3
-  - uid: 205
+  - uid: 323
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2262,7 +2311,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 3
-  - uid: 206
+  - uid: 324
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2271,7 +2320,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 3
-  - uid: 207
+  - uid: 325
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2282,25 +2331,25 @@ entities:
       - 3
 - proto: Gaslock
   entities:
-  - uid: 208
+  - uid: 326
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,1.5
       parent: 1
-  - uid: 209
+  - uid: 327
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,1.5
       parent: 1
-  - uid: 210
+  - uid: 328
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,-13.5
       parent: 1
-  - uid: 211
+  - uid: 329
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2310,56 +2359,56 @@ entities:
       color: '#692569FF'
 - proto: GaslockFrame
   entities:
-  - uid: 212
+  - uid: 330
     components:
     - type: Transform
       pos: 2.5,2.5
       parent: 1
-  - uid: 213
+  - uid: 331
     components:
     - type: Transform
       pos: 3.5,2.5
       parent: 1
 - proto: GasMiningDrill
   entities:
-  - uid: 214
+  - uid: 332
     components:
     - type: Transform
       pos: 3.5,3.5
       parent: 1
-  - uid: 215
+  - uid: 333
     components:
     - type: Transform
       pos: 2.5,3.5
       parent: 1
 - proto: GasMixerOnFlipped
   entities:
-  - uid: 216
+  - uid: 334
     components:
     - type: Transform
       pos: 1.5,-19.5
       parent: 1
 - proto: GasOutletInjector
   entities:
-  - uid: 217
+  - uid: 335
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-5.5
       parent: 1
-  - uid: 218
+  - uid: 336
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-3.5
       parent: 1
-  - uid: 219
+  - uid: 337
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-1.5
       parent: 1
-  - uid: 220
+  - uid: 338
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2367,31 +2416,31 @@ entities:
       parent: 1
 - proto: GasPassiveVent
   entities:
-  - uid: 221
+  - uid: 339
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,0.5
       parent: 1
-  - uid: 222
+  - uid: 340
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-1.5
       parent: 1
-  - uid: 223
+  - uid: 341
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-3.5
       parent: 1
-  - uid: 224
+  - uid: 342
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-5.5
       parent: 1
-  - uid: 225
+  - uid: 343
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2399,18 +2448,18 @@ entities:
       parent: 1
 - proto: GasPipeBend
   entities:
-  - uid: 226
+  - uid: 344
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-20.5
       parent: 1
-  - uid: 227
+  - uid: 345
     components:
     - type: Transform
       pos: 1.5,-18.5
       parent: 1
-  - uid: 228
+  - uid: 346
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2418,7 +2467,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#1A3373FF'
-  - uid: 229
+  - uid: 347
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2426,7 +2475,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#1A3373FF'
-  - uid: 230
+  - uid: 348
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2434,7 +2483,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#692569FF'
-  - uid: 231
+  - uid: 349
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2442,7 +2491,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#692569FF'
-  - uid: 232
+  - uid: 350
     components:
     - type: Transform
       pos: 7.5,-14.5
@@ -2451,55 +2500,55 @@ entities:
       color: '#5C1919FF'
 - proto: GasPipeStraight
   entities:
-  - uid: 233
+  - uid: 351
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,-5.5
       parent: 1
-  - uid: 234
+  - uid: 352
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,-3.5
       parent: 1
-  - uid: 235
+  - uid: 353
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-1.5
       parent: 1
-  - uid: 236
+  - uid: 354
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,0.5
       parent: 1
-  - uid: 237
+  - uid: 355
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-5.5
       parent: 1
-  - uid: 238
+  - uid: 356
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-3.5
       parent: 1
-  - uid: 239
+  - uid: 357
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-1.5
       parent: 1
-  - uid: 240
+  - uid: 358
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,0.5
       parent: 1
-  - uid: 241
+  - uid: 359
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2507,7 +2556,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#1A3373FF'
-  - uid: 242
+  - uid: 360
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2515,7 +2564,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#1A3373FF'
-  - uid: 243
+  - uid: 361
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2523,7 +2572,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#1A3373FF'
-  - uid: 244
+  - uid: 362
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2531,7 +2580,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#1A3373FF'
-  - uid: 245
+  - uid: 363
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2539,7 +2588,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#1A3373FF'
-  - uid: 246
+  - uid: 364
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2547,7 +2596,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#1A3373FF'
-  - uid: 247
+  - uid: 365
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2555,7 +2604,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#1A3373FF'
-  - uid: 248
+  - uid: 366
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2563,7 +2612,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#1A3373FF'
-  - uid: 249
+  - uid: 367
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2571,7 +2620,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#1A3373FF'
-  - uid: 250
+  - uid: 368
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2579,7 +2628,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#1A3373FF'
-  - uid: 251
+  - uid: 369
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2587,7 +2636,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#1A3373FF'
-  - uid: 252
+  - uid: 370
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2595,7 +2644,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#1A3373FF'
-  - uid: 253
+  - uid: 371
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2603,7 +2652,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#1A3373FF'
-  - uid: 254
+  - uid: 372
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2611,7 +2660,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#1A3373FF'
-  - uid: 255
+  - uid: 373
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2619,7 +2668,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#1A3373FF'
-  - uid: 256
+  - uid: 374
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2627,35 +2676,35 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#1A3373FF'
-  - uid: 257
+  - uid: 375
     components:
     - type: Transform
       pos: 2.5,-10.5
       parent: 1
     - type: AtmosPipeColor
       color: '#1A3373FF'
-  - uid: 258
+  - uid: 376
     components:
     - type: Transform
       pos: 2.5,-11.5
       parent: 1
     - type: AtmosPipeColor
       color: '#1A3373FF'
-  - uid: 259
+  - uid: 377
     components:
     - type: Transform
       pos: 2.5,-12.5
       parent: 1
     - type: AtmosPipeColor
       color: '#1A3373FF'
-  - uid: 260
+  - uid: 378
     components:
     - type: Transform
       pos: 2.5,-13.5
       parent: 1
     - type: AtmosPipeColor
       color: '#1A3373FF'
-  - uid: 261
+  - uid: 379
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2663,7 +2712,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#1A3373FF'
-  - uid: 262
+  - uid: 380
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2671,7 +2720,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#1A3373FF'
-  - uid: 263
+  - uid: 381
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2679,7 +2728,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#1A3373FF'
-  - uid: 264
+  - uid: 382
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2687,7 +2736,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#1A3373FF'
-  - uid: 265
+  - uid: 383
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2695,7 +2744,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#1A3373FF'
-  - uid: 266
+  - uid: 384
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2703,7 +2752,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#1A3373FF'
-  - uid: 267
+  - uid: 385
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2711,7 +2760,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#692569FF'
-  - uid: 268
+  - uid: 386
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2719,7 +2768,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#692569FF'
-  - uid: 269
+  - uid: 387
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2727,7 +2776,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#692569FF'
-  - uid: 270
+  - uid: 388
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2735,7 +2784,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#692569FF'
-  - uid: 271
+  - uid: 389
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2743,7 +2792,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#692569FF'
-  - uid: 272
+  - uid: 390
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2751,7 +2800,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#692569FF'
-  - uid: 273
+  - uid: 391
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2759,7 +2808,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#692569FF'
-  - uid: 274
+  - uid: 392
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2767,7 +2816,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#692569FF'
-  - uid: 275
+  - uid: 393
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2775,7 +2824,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#692569FF'
-  - uid: 276
+  - uid: 394
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2783,7 +2832,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#692569FF'
-  - uid: 277
+  - uid: 395
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2791,7 +2840,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#692569FF'
-  - uid: 278
+  - uid: 396
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2799,7 +2848,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#692569FF'
-  - uid: 279
+  - uid: 397
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2807,7 +2856,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#1A3373FF'
-  - uid: 280
+  - uid: 398
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2815,7 +2864,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#1A3373FF'
-  - uid: 281
+  - uid: 399
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2823,7 +2872,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#1A3373FF'
-  - uid: 282
+  - uid: 400
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2831,7 +2880,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#1A3373FF'
-  - uid: 283
+  - uid: 401
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2839,7 +2888,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#5C1919FF'
-  - uid: 284
+  - uid: 402
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2847,7 +2896,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#5C1919FF'
-  - uid: 285
+  - uid: 403
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2855,7 +2904,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#5C1919FF'
-  - uid: 286
+  - uid: 404
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2863,147 +2912,147 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#5C1919FF'
-  - uid: 287
+  - uid: 405
     components:
     - type: Transform
       pos: 3.5,-13.5
       parent: 1
     - type: AtmosPipeColor
       color: '#5C1919FF'
-  - uid: 288
+  - uid: 406
     components:
     - type: Transform
       pos: 3.5,-12.5
       parent: 1
     - type: AtmosPipeColor
       color: '#5C1919FF'
-  - uid: 289
+  - uid: 407
     components:
     - type: Transform
       pos: 3.5,-11.5
       parent: 1
     - type: AtmosPipeColor
       color: '#5C1919FF'
-  - uid: 290
+  - uid: 408
     components:
     - type: Transform
       pos: 3.5,-10.5
       parent: 1
     - type: AtmosPipeColor
       color: '#5C1919FF'
-  - uid: 291
+  - uid: 409
     components:
     - type: Transform
       pos: 3.5,-8.5
       parent: 1
     - type: AtmosPipeColor
       color: '#5C1919FF'
-  - uid: 292
+  - uid: 410
     components:
     - type: Transform
       pos: 3.5,-7.5
       parent: 1
     - type: AtmosPipeColor
       color: '#5C1919FF'
-  - uid: 293
+  - uid: 411
     components:
     - type: Transform
       pos: 3.5,-6.5
       parent: 1
     - type: AtmosPipeColor
       color: '#5C1919FF'
-  - uid: 294
+  - uid: 412
     components:
     - type: Transform
       pos: 3.5,-5.5
       parent: 1
     - type: AtmosPipeColor
       color: '#5C1919FF'
-  - uid: 295
+  - uid: 413
     components:
     - type: Transform
       pos: 3.5,-4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#5C1919FF'
-  - uid: 296
+  - uid: 414
     components:
     - type: Transform
       pos: 3.5,-3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#5C1919FF'
-  - uid: 297
+  - uid: 415
     components:
     - type: Transform
       pos: 3.5,-2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#5C1919FF'
-  - uid: 298
+  - uid: 416
     components:
     - type: Transform
       pos: 3.5,-1.5
       parent: 1
     - type: AtmosPipeColor
       color: '#5C1919FF'
-  - uid: 299
+  - uid: 417
     components:
     - type: Transform
       pos: 3.5,-0.5
       parent: 1
     - type: AtmosPipeColor
       color: '#5C1919FF'
-  - uid: 300
+  - uid: 418
     components:
     - type: Transform
       pos: 3.5,0.5
       parent: 1
     - type: AtmosPipeColor
       color: '#5C1919FF'
-  - uid: 301
+  - uid: 419
     components:
     - type: Transform
       pos: 3.5,1.5
       parent: 1
     - type: AtmosPipeColor
       color: '#5C1919FF'
-  - uid: 302
+  - uid: 420
     components:
     - type: Transform
       pos: 3.5,2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#5C1919FF'
-  - uid: 303
+  - uid: 421
     components:
     - type: Transform
       pos: 3.5,3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#5C1919FF'
-  - uid: 304
+  - uid: 422
     components:
     - type: Transform
       pos: 3.5,4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#5C1919FF'
-  - uid: 305
+  - uid: 423
     components:
     - type: Transform
       pos: 3.5,6.5
       parent: 1
     - type: AtmosPipeColor
       color: '#5C1919FF'
-  - uid: 306
+  - uid: 424
     components:
     - type: Transform
       pos: 3.5,7.5
       parent: 1
     - type: AtmosPipeColor
       color: '#5C1919FF'
-  - uid: 307
+  - uid: 425
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3011,7 +3060,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#5C1919FF'
-  - uid: 308
+  - uid: 426
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3019,38 +3068,38 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#5C1919FF'
-  - uid: 309
+  - uid: 427
     components:
     - type: Transform
       pos: 7.5,-15.5
       parent: 1
     - type: AtmosPipeColor
       color: '#5C1919FF'
-  - uid: 310
+  - uid: 428
     components:
     - type: Transform
       pos: 7.5,-16.5
       parent: 1
     - type: AtmosPipeColor
       color: '#5C1919FF'
-  - uid: 311
+  - uid: 429
     components:
     - type: Transform
       pos: 7.5,-18.5
       parent: 1
-  - uid: 312
+  - uid: 430
     components:
     - type: Transform
       pos: 7.5,-19.5
       parent: 1
-  - uid: 313
+  - uid: 431
     components:
     - type: Transform
       pos: 7.5,-20.5
       parent: 1
 - proto: GasPipeTJunction
   entities:
-  - uid: 314
+  - uid: 432
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3058,7 +3107,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#1A3373FF'
-  - uid: 315
+  - uid: 433
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3066,7 +3115,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#1A3373FF'
-  - uid: 316
+  - uid: 434
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3074,7 +3123,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#1A3373FF'
-  - uid: 317
+  - uid: 435
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3082,7 +3131,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#1A3373FF'
-  - uid: 318
+  - uid: 436
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3090,7 +3139,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#5C1919FF'
-  - uid: 319
+  - uid: 437
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3098,7 +3147,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#5C1919FF'
-  - uid: 320
+  - uid: 438
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3106,7 +3155,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#5C1919FF'
-  - uid: 321
+  - uid: 439
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3116,13 +3165,13 @@ entities:
       color: '#5C1919FF'
 - proto: GasPort
   entities:
-  - uid: 322
+  - uid: 440
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,-19.5
       parent: 1
-  - uid: 323
+  - uid: 441
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3130,7 +3179,7 @@ entities:
       parent: 1
 - proto: GasPressurePumpOn
   entities:
-  - uid: 324
+  - uid: 442
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3138,7 +3187,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#1A3373FF'
-  - uid: 325
+  - uid: 443
     components:
     - type: Transform
       pos: 7.5,-17.5
@@ -3147,7 +3196,7 @@ entities:
       color: '#5C1919FF'
 - proto: GasVentPump
   entities:
-  - uid: 326
+  - uid: 444
     components:
     - type: Transform
       pos: -0.5,-13.5
@@ -3157,7 +3206,7 @@ entities:
       - 3
     - type: AtmosPipeColor
       color: '#1A3373FF'
-  - uid: 327
+  - uid: 445
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3168,7 +3217,7 @@ entities:
       - 4
     - type: AtmosPipeColor
       color: '#1A3373FF'
-  - uid: 328
+  - uid: 446
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3179,7 +3228,7 @@ entities:
       - 6
     - type: AtmosPipeColor
       color: '#1A3373FF'
-  - uid: 329
+  - uid: 447
     components:
     - type: Transform
       pos: 2.5,8.5
@@ -3189,7 +3238,7 @@ entities:
       - 5
     - type: AtmosPipeColor
       color: '#1A3373FF'
-  - uid: 330
+  - uid: 448
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3202,7 +3251,7 @@ entities:
       color: '#1A3373FF'
 - proto: GasVentScrubber
   entities:
-  - uid: 331
+  - uid: 449
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3213,7 +3262,7 @@ entities:
       - 4
     - type: AtmosPipeColor
       color: '#5C1919FF'
-  - uid: 332
+  - uid: 450
     components:
     - type: Transform
       pos: 6.5,-13.5
@@ -3223,7 +3272,7 @@ entities:
       - 3
     - type: AtmosPipeColor
       color: '#5C1919FF'
-  - uid: 333
+  - uid: 451
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3234,7 +3283,7 @@ entities:
       - 2
     - type: AtmosPipeColor
       color: '#5C1919FF'
-  - uid: 334
+  - uid: 452
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3245,7 +3294,7 @@ entities:
       - 6
     - type: AtmosPipeColor
       color: '#5C1919FF'
-  - uid: 335
+  - uid: 453
     components:
     - type: Transform
       pos: 3.5,8.5
@@ -3257,156 +3306,156 @@ entities:
       color: '#5C1919FF'
 - proto: GravityGeneratorMini
   entities:
-  - uid: 336
+  - uid: 454
     components:
     - type: Transform
       pos: 4.5,-20.5
       parent: 1
 - proto: Grille
   entities:
-  - uid: 337
+  - uid: 455
     components:
     - type: Transform
       pos: 0.5,-1.5
       parent: 1
-  - uid: 338
+  - uid: 456
     components:
     - type: Transform
       pos: 0.5,0.5
       parent: 1
-  - uid: 339
+  - uid: 457
     components:
     - type: Transform
       pos: 0.5,-3.5
       parent: 1
-  - uid: 340
+  - uid: 458
     components:
     - type: Transform
       pos: 0.5,-5.5
       parent: 1
-  - uid: 341
+  - uid: 459
     components:
     - type: Transform
       pos: 5.5,-3.5
       parent: 1
-  - uid: 342
+  - uid: 460
     components:
     - type: Transform
       pos: 5.5,-5.5
       parent: 1
-  - uid: 343
+  - uid: 461
     components:
     - type: Transform
       pos: 5.5,-1.5
       parent: 1
-  - uid: 344
+  - uid: 462
     components:
     - type: Transform
       pos: 5.5,0.5
       parent: 1
-  - uid: 345
+  - uid: 463
     components:
     - type: Transform
       pos: 1.5,-16.5
       parent: 1
-  - uid: 346
+  - uid: 464
     components:
     - type: Transform
       pos: 2.5,-16.5
       parent: 1
-  - uid: 347
+  - uid: 465
     components:
     - type: Transform
       pos: 3.5,-16.5
       parent: 1
-  - uid: 348
+  - uid: 466
     components:
     - type: Transform
       pos: 4.5,-16.5
       parent: 1
-  - uid: 349
+  - uid: 467
     components:
     - type: Transform
       pos: 8.5,-10.5
       parent: 1
-  - uid: 350
+  - uid: 468
     components:
     - type: Transform
       pos: -2.5,-10.5
       parent: 1
-  - uid: 351
+  - uid: 469
     components:
     - type: Transform
       pos: 2.5,-0.5
       parent: 1
-  - uid: 352
+  - uid: 470
     components:
     - type: Transform
       pos: 3.5,-0.5
       parent: 1
-  - uid: 353
+  - uid: 471
     components:
     - type: Transform
       pos: 3.5,-2.5
       parent: 1
-  - uid: 354
+  - uid: 472
     components:
     - type: Transform
       pos: 2.5,-2.5
       parent: 1
-  - uid: 355
+  - uid: 473
     components:
     - type: Transform
       pos: 2.5,-4.5
       parent: 1
-  - uid: 356
+  - uid: 474
     components:
     - type: Transform
       pos: 3.5,-4.5
       parent: 1
-  - uid: 642
+  - uid: 475
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,10.5
       parent: 1
-  - uid: 643
+  - uid: 476
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,11.5
       parent: 1
-  - uid: 644
+  - uid: 477
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,11.5
       parent: 1
-  - uid: 645
+  - uid: 478
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,12.5
       parent: 1
-  - uid: 646
+  - uid: 479
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,12.5
       parent: 1
-  - uid: 647
+  - uid: 480
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,11.5
       parent: 1
-  - uid: 648
+  - uid: 481
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,11.5
       parent: 1
-  - uid: 649
+  - uid: 482
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3414,35 +3463,35 @@ entities:
       parent: 1
 - proto: GrilleDiagonal
   entities:
-  - uid: 636
+  - uid: 483
     components:
     - type: Transform
       pos: -0.5,11.5
       parent: 1
-  - uid: 637
+  - uid: 484
     components:
     - type: Transform
       pos: 0.5,12.5
       parent: 1
-  - uid: 638
+  - uid: 485
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,12.5
       parent: 1
-  - uid: 639
+  - uid: 486
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,11.5
       parent: 1
-  - uid: 640
+  - uid: 487
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,10.5
       parent: 1
-  - uid: 641
+  - uid: 488
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3450,7 +3499,7 @@ entities:
       parent: 1
 - proto: Gyroscope
   entities:
-  - uid: 357
+  - uid: 489
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3458,28 +3507,28 @@ entities:
       parent: 1
 - proto: LockerAtmosphericsFilledHardsuit
   entities:
-  - uid: 358
+  - uid: 490
     components:
     - type: Transform
       pos: 3.5,-7.5
       parent: 1
 - proto: LockerChiefEngineerFilledHardsuit
   entities:
-  - uid: 359
+  - uid: 491
     components:
     - type: Transform
       pos: 5.5,8.5
       parent: 1
 - proto: LockerSalvageSpecialistFilled
   entities:
-  - uid: 360
+  - uid: 492
     components:
     - type: Transform
       pos: 3.5,-11.5
       parent: 1
 - proto: LockerWallEVAColorAtmosTechFilled
   entities:
-  - uid: 361
+  - uid: 493
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3487,7 +3536,7 @@ entities:
       parent: 1
 - proto: LockerWallMaterialsFuelAmeJarFilled
   entities:
-  - uid: 362
+  - uid: 494
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3495,77 +3544,77 @@ entities:
       parent: 1
 - proto: LockerWallMaterialsFuelWeldingFilled
   entities:
-  - uid: 363
+  - uid: 495
     components:
     - type: Transform
       pos: 1.5,7.5
       parent: 1
 - proto: MachineFlatpacker
   entities:
-  - uid: 364
+  - uid: 496
     components:
     - type: Transform
       pos: 1.5,-15.5
       parent: 1
 - proto: MachineMaterialSilo
   entities:
-  - uid: 365
+  - uid: 497
     components:
     - type: Transform
       pos: 1.5,-17.5
       parent: 1
 - proto: MaterialReclaimer
   entities:
-  - uid: 366
+  - uid: 498
     components:
     - type: Transform
       pos: 7.5,-18.5
       parent: 1
 - proto: MopItem
   entities:
-  - uid: 367
+  - uid: 499
     components:
     - type: Transform
       pos: 7.511179,-17.535309
       parent: 1
 - proto: NFHolopadShip
   entities:
-  - uid: 368
+  - uid: 500
     components:
     - type: Transform
       pos: 4.5,8.5
       parent: 1
 - proto: NitrogenCanister
   entities:
-  - uid: 369
+  - uid: 501
     components:
     - type: Transform
       pos: 0.5,-20.5
       parent: 1
 - proto: OreProcessor
   entities:
-  - uid: 370
+  - uid: 502
     components:
     - type: Transform
       pos: 2.5,-15.5
       parent: 1
 - proto: OxygenCanister
   entities:
-  - uid: 371
+  - uid: 503
     components:
     - type: Transform
       pos: 0.5,-19.5
       parent: 1
 - proto: PortableGeneratorJrPacman
   entities:
-  - uid: 372
+  - uid: 504
     components:
     - type: Transform
       pos: 1.5,5.5
       parent: 1
 - proto: PosterLegitSafetyMothFires
   entities:
-  - uid: 373
+  - uid: 505
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3573,44 +3622,44 @@ entities:
       parent: 1
 - proto: PottedPlant24
   entities:
-  - uid: 374
+  - uid: 506
     components:
     - type: Transform
       pos: 0.5,8.5
       parent: 1
 - proto: PoweredLEDSmallLight
   entities:
-  - uid: 375
+  - uid: 507
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,-1.5
       parent: 1
-  - uid: 376
+  - uid: 508
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-3.5
       parent: 1
-  - uid: 377
+  - uid: 509
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-1.5
       parent: 1
-  - uid: 378
+  - uid: 510
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,-3.5
       parent: 1
-  - uid: 379
+  - uid: 511
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,-10.5
       parent: 1
-  - uid: 380
+  - uid: 512
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3618,82 +3667,82 @@ entities:
       parent: 1
 - proto: PoweredlightExterior
   entities:
-  - uid: 381
+  - uid: 513
     components:
     - type: Transform
       pos: 3.5,-22.5
       parent: 1
-  - uid: 382
+  - uid: 514
     components:
     - type: Transform
       pos: 2.5,-22.5
       parent: 1
 - proto: PoweredlightLED
   entities:
-  - uid: 383
+  - uid: 515
     components:
     - type: Transform
       pos: 3.5,-7.5
       parent: 1
-  - uid: 384
+  - uid: 516
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,-13.5
       parent: 1
-  - uid: 385
+  - uid: 517
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-13.5
       parent: 1
-  - uid: 386
+  - uid: 518
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,-5.5
       parent: 1
-  - uid: 387
+  - uid: 519
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-5.5
       parent: 1
-  - uid: 388
+  - uid: 520
     components:
     - type: Transform
       pos: 6.5,2.5
       parent: 1
-  - uid: 389
+  - uid: 521
     components:
     - type: Transform
       pos: -0.5,2.5
       parent: 1
-  - uid: 390
+  - uid: 522
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,5.5
       parent: 1
-  - uid: 391
+  - uid: 523
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,5.5
       parent: 1
-  - uid: 392
+  - uid: 524
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,9.5
       parent: 1
-  - uid: 393
+  - uid: 525
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,9.5
       parent: 1
-  - uid: 394
+  - uid: 526
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3701,7 +3750,7 @@ entities:
       parent: 1
 - proto: PoweredlightOrange
   entities:
-  - uid: 395
+  - uid: 527
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3709,13 +3758,13 @@ entities:
       parent: 1
 - proto: PoweredWarmSmallLight
   entities:
-  - uid: 397
+  - uid: 528
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-18.5
       parent: 1
-  - uid: 398
+  - uid: 529
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3723,177 +3772,177 @@ entities:
       parent: 1
 - proto: ReinforcedWindow
   entities:
-  - uid: 399
+  - uid: 530
     components:
     - type: Transform
       pos: 0.5,-5.5
       parent: 1
-  - uid: 400
+  - uid: 531
     components:
     - type: Transform
       pos: 5.5,-5.5
       parent: 1
-  - uid: 401
+  - uid: 532
     components:
     - type: Transform
       pos: 5.5,-3.5
       parent: 1
-  - uid: 402
+  - uid: 533
     components:
     - type: Transform
       pos: 0.5,-3.5
       parent: 1
-  - uid: 403
+  - uid: 534
     components:
     - type: Transform
       pos: 0.5,-1.5
       parent: 1
-  - uid: 404
+  - uid: 535
     components:
     - type: Transform
       pos: 5.5,-1.5
       parent: 1
-  - uid: 405
+  - uid: 536
     components:
     - type: Transform
       pos: 5.5,0.5
       parent: 1
-  - uid: 406
+  - uid: 537
     components:
     - type: Transform
       pos: 0.5,0.5
       parent: 1
-  - uid: 407
+  - uid: 538
     components:
     - type: Transform
       pos: 1.5,12.5
       parent: 1
-  - uid: 408
+  - uid: 539
     components:
     - type: Transform
       pos: 4.5,12.5
       parent: 1
-  - uid: 409
+  - uid: 540
     components:
     - type: Transform
       pos: 5.5,11.5
       parent: 1
-  - uid: 410
+  - uid: 541
     components:
     - type: Transform
       pos: 0.5,11.5
       parent: 1
-  - uid: 411
+  - uid: 542
     components:
     - type: Transform
       pos: 1.5,11.5
       parent: 1
-  - uid: 412
+  - uid: 543
     components:
     - type: Transform
       pos: 4.5,11.5
       parent: 1
-  - uid: 413
+  - uid: 544
     components:
     - type: Transform
       pos: 6.5,10.5
       parent: 1
-  - uid: 414
+  - uid: 545
     components:
     - type: Transform
       pos: -0.5,10.5
       parent: 1
-  - uid: 415
+  - uid: 546
     components:
     - type: Transform
       pos: -2.5,-10.5
       parent: 1
-  - uid: 416
+  - uid: 547
     components:
     - type: Transform
       pos: 8.5,-10.5
       parent: 1
-  - uid: 417
+  - uid: 548
     components:
     - type: Transform
       pos: 3.5,-2.5
       parent: 1
-  - uid: 418
+  - uid: 549
     components:
     - type: Transform
       pos: 2.5,-2.5
       parent: 1
-  - uid: 419
+  - uid: 550
     components:
     - type: Transform
       pos: 2.5,-4.5
       parent: 1
-  - uid: 420
+  - uid: 551
     components:
     - type: Transform
       pos: 3.5,-4.5
       parent: 1
-  - uid: 421
+  - uid: 552
     components:
     - type: Transform
       pos: 4.5,-16.5
       parent: 1
-  - uid: 422
+  - uid: 553
     components:
     - type: Transform
       pos: 1.5,-16.5
       parent: 1
-  - uid: 423
+  - uid: 554
     components:
     - type: Transform
       pos: 3.5,-16.5
       parent: 1
-  - uid: 424
+  - uid: 555
     components:
     - type: Transform
       pos: 2.5,-16.5
       parent: 1
-  - uid: 425
+  - uid: 556
     components:
     - type: Transform
       pos: 3.5,-0.5
       parent: 1
-  - uid: 426
+  - uid: 557
     components:
     - type: Transform
       pos: 2.5,-0.5
       parent: 1
 - proto: ReinforcedWindowDiagonal
   entities:
-  - uid: 427
+  - uid: 558
     components:
     - type: Transform
       pos: 0.5,12.5
       parent: 1
-  - uid: 428
+  - uid: 559
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,12.5
       parent: 1
-  - uid: 429
+  - uid: 560
     components:
     - type: Transform
       pos: -0.5,11.5
       parent: 1
-  - uid: 430
+  - uid: 561
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,11.5
       parent: 1
-  - uid: 431
+  - uid: 562
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,10.5
       parent: 1
-  - uid: 432
+  - uid: 563
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3901,46 +3950,46 @@ entities:
       parent: 1
 - proto: ShelfWallFreezerDark
   entities:
-  - uid: 433
+  - uid: 564
     components:
     - type: Transform
       pos: 2.5,-6.5
       parent: 1
 - proto: ShuttersWindowOpen
   entities:
-  - uid: 434
+  - uid: 565
     components:
     - type: Transform
       pos: 1.5,-16.5
       parent: 1
-  - uid: 435
+  - uid: 566
     components:
     - type: Transform
       pos: 2.5,-16.5
       parent: 1
-  - uid: 436
+  - uid: 567
     components:
     - type: Transform
       pos: 3.5,-16.5
       parent: 1
-  - uid: 437
+  - uid: 568
     components:
     - type: Transform
       pos: 4.5,-16.5
       parent: 1
-  - uid: 438
+  - uid: 569
     components:
     - type: Transform
       pos: -2.5,-10.5
       parent: 1
-  - uid: 439
+  - uid: 570
     components:
     - type: Transform
       pos: 8.5,-10.5
       parent: 1
 - proto: SignalButton
   entities:
-  - uid: 440
+  - uid: 571
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3948,105 +3997,105 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        434:
+        565:
         - - Pressed
           - Open
         - - Pressed
           - Close
-        435:
+        566:
         - - Pressed
           - Open
         - - Pressed
           - Close
-        436:
+        567:
         - - Pressed
           - Open
         - - Pressed
           - Close
-        437:
+        568:
         - - Pressed
           - Open
         - - Pressed
           - Close
-        439:
+        570:
         - - Pressed
           - Open
         - - Pressed
           - Close
-        438:
+        569:
         - - Pressed
           - Open
         - - Pressed
           - Close
 - proto: SMESBasic
   entities:
-  - uid: 441
+  - uid: 572
     components:
     - type: Transform
       pos: 2.5,-17.5
       parent: 1
 - proto: SpawnPointContractor
   entities:
-  - uid: 769
+  - uid: 573
     components:
     - type: Transform
       pos: 4.5,-8.5
       parent: 1
 - proto: SpawnPointLatejoin
   entities:
-  - uid: 442
+  - uid: 574
     components:
     - type: Transform
       pos: 4.5,-10.5
       parent: 1
 - proto: SpawnPointMercenary
   entities:
-  - uid: 396
+  - uid: 575
     components:
     - type: Transform
       pos: 3.5,-10.5
       parent: 1
 - proto: SpawnPointPilot
   entities:
-  - uid: 768
+  - uid: 576
     components:
     - type: Transform
       pos: 2.5,-10.5
       parent: 1
 - proto: StorageCanister
   entities:
-  - uid: 443
+  - uid: 577
     components:
     - type: Transform
       pos: 2.5,5.5
       parent: 1
-  - uid: 444
+  - uid: 578
     components:
     - type: Transform
       pos: 3.5,5.5
       parent: 1
 - proto: SubstationBasic
   entities:
-  - uid: 445
+  - uid: 579
     components:
     - type: Transform
       pos: 0.5,-17.5
       parent: 1
 - proto: TableReinforced
   entities:
-  - uid: 446
+  - uid: 580
     components:
     - type: Transform
       pos: 4.5,10.5
       parent: 1
-  - uid: 447
+  - uid: 581
     components:
     - type: Transform
       pos: 1.5,10.5
       parent: 1
 - proto: TableWood
   entities:
-  - uid: 448
+  - uid: 582
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4054,13 +4103,13 @@ entities:
       parent: 1
 - proto: TableWoodReinforced
   entities:
-  - uid: 449
+  - uid: 583
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-11.5
       parent: 1
-  - uid: 450
+  - uid: 584
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4068,105 +4117,105 @@ entities:
       parent: 1
 - proto: Thruster
   entities:
-  - uid: 451
+  - uid: 585
     components:
     - type: Transform
       pos: 9.5,-7.5
       parent: 1
-  - uid: 452
+  - uid: 586
     components:
     - type: Transform
       pos: -3.5,-7.5
       parent: 1
-  - uid: 453
+  - uid: 587
     components:
     - type: Transform
       pos: 2.5,12.5
       parent: 1
-  - uid: 454
+  - uid: 588
     components:
     - type: Transform
       pos: 3.5,12.5
       parent: 1
-  - uid: 455
+  - uid: 589
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,-10.5
       parent: 1
-  - uid: 456
+  - uid: 590
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-10.5
       parent: 1
-  - uid: 457
+  - uid: 591
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-22.5
       parent: 1
-  - uid: 458
+  - uid: 592
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-22.5
       parent: 1
-  - uid: 459
+  - uid: 593
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-20.5
       parent: 1
-  - uid: 460
+  - uid: 594
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-20.5
       parent: 1
-  - uid: 461
+  - uid: 595
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,-20.5
       parent: 1
-  - uid: 462
+  - uid: 596
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-20.5
       parent: 1
-  - uid: 463
+  - uid: 597
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-22.5
       parent: 1
-  - uid: 464
+  - uid: 598
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-22.5
       parent: 1
-  - uid: 465
+  - uid: 599
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-17.5
       parent: 1
-  - uid: 466
+  - uid: 600
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-16.5
       parent: 1
-  - uid: 467
+  - uid: 601
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,-16.5
       parent: 1
-  - uid: 468
+  - uid: 602
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4174,616 +4223,616 @@ entities:
       parent: 1
 - proto: VendingMachineSalvage
   entities:
-  - uid: 469
+  - uid: 603
     components:
     - type: Transform
       pos: 4.5,-15.5
       parent: 1
 - proto: VendingMachineTankDispenserEVA
   entities:
-  - uid: 470
+  - uid: 604
     components:
     - type: Transform
       pos: 6.5,-15.5
       parent: 1
 - proto: WallReinforced
   entities:
-  - uid: 471
+  - uid: 605
     components:
     - type: Transform
       pos: 1.5,1.5
       parent: 1
-  - uid: 472
+  - uid: 606
     components:
     - type: Transform
       pos: 2.5,1.5
       parent: 1
-  - uid: 473
+  - uid: 607
     components:
     - type: Transform
       pos: 3.5,1.5
       parent: 1
-  - uid: 474
+  - uid: 608
     components:
     - type: Transform
       pos: 4.5,1.5
       parent: 1
-  - uid: 475
+  - uid: 609
     components:
     - type: Transform
       pos: 2.5,-6.5
       parent: 1
-  - uid: 476
+  - uid: 610
     components:
     - type: Transform
       pos: 3.5,-6.5
       parent: 1
-  - uid: 477
+  - uid: 611
     components:
     - type: Transform
       pos: 4.5,-6.5
       parent: 1
-  - uid: 478
+  - uid: 612
     components:
     - type: Transform
       pos: 5.5,-6.5
       parent: 1
-  - uid: 479
+  - uid: 613
     components:
     - type: Transform
       pos: 0.5,-2.5
       parent: 1
-  - uid: 480
+  - uid: 614
     components:
     - type: Transform
       pos: 5.5,-4.5
       parent: 1
-  - uid: 481
+  - uid: 615
     components:
     - type: Transform
       pos: 5.5,-2.5
       parent: 1
-  - uid: 482
+  - uid: 616
     components:
     - type: Transform
       pos: 5.5,-0.5
       parent: 1
-  - uid: 483
+  - uid: 617
     components:
     - type: Transform
       pos: 0.5,-0.5
       parent: 1
-  - uid: 484
+  - uid: 618
     components:
     - type: Transform
       pos: 5.5,-7.5
       parent: 1
-  - uid: 485
+  - uid: 619
     components:
     - type: Transform
       pos: 1.5,-6.5
       parent: 1
-  - uid: 486
+  - uid: 620
     components:
     - type: Transform
       pos: 0.5,-4.5
       parent: 1
-  - uid: 487
+  - uid: 621
     components:
     - type: Transform
       pos: 0.5,-6.5
       parent: 1
-  - uid: 488
+  - uid: 622
     components:
     - type: Transform
       pos: -0.5,-8.5
       parent: 1
-  - uid: 489
+  - uid: 623
     components:
     - type: Transform
       pos: -2.5,2.5
       parent: 1
-  - uid: 490
+  - uid: 624
     components:
     - type: Transform
       pos: -2.5,4.5
       parent: 1
-  - uid: 491
+  - uid: 625
     components:
     - type: Transform
       pos: 0.5,-7.5
       parent: 1
-  - uid: 492
+  - uid: 626
     components:
     - type: Transform
       pos: 6.5,-8.5
       parent: 1
-  - uid: 493
+  - uid: 627
     components:
     - type: Transform
       pos: 8.5,2.5
       parent: 1
-  - uid: 494
+  - uid: 628
     components:
     - type: Transform
       pos: 8.5,3.5
       parent: 1
-  - uid: 495
+  - uid: 629
     components:
     - type: Transform
       pos: -2.5,3.5
       parent: 1
-  - uid: 496
+  - uid: 630
     components:
     - type: Transform
       pos: 6.5,3.5
       parent: 1
-  - uid: 497
+  - uid: 631
     components:
     - type: Transform
       pos: 0.5,4.5
       parent: 1
-  - uid: 498
+  - uid: 632
     components:
     - type: Transform
       pos: 1.5,4.5
       parent: 1
-  - uid: 499
+  - uid: 633
     components:
     - type: Transform
       pos: 2.5,4.5
       parent: 1
-  - uid: 500
+  - uid: 634
     components:
     - type: Transform
       pos: 3.5,4.5
       parent: 1
-  - uid: 501
+  - uid: 635
     components:
     - type: Transform
       pos: 4.5,4.5
       parent: 1
-  - uid: 502
+  - uid: 636
     components:
     - type: Transform
       pos: 5.5,4.5
       parent: 1
-  - uid: 503
+  - uid: 637
     components:
     - type: Transform
       pos: -0.5,3.5
       parent: 1
-  - uid: 504
+  - uid: 638
     components:
     - type: Transform
       pos: 8.5,4.5
       parent: 1
-  - uid: 505
+  - uid: 639
     components:
     - type: Transform
       pos: 8.5,-8.5
       parent: 1
-  - uid: 506
+  - uid: 640
     components:
     - type: Transform
       pos: 8.5,-9.5
       parent: 1
-  - uid: 507
+  - uid: 641
     components:
     - type: Transform
       pos: 8.5,-7.5
       parent: 1
-  - uid: 508
+  - uid: 642
     components:
     - type: Transform
       pos: -2.5,-7.5
       parent: 1
-  - uid: 509
+  - uid: 643
     components:
     - type: Transform
       pos: -2.5,-8.5
       parent: 1
-  - uid: 510
+  - uid: 644
     components:
     - type: Transform
       pos: -2.5,-9.5
       parent: 1
-  - uid: 511
+  - uid: 645
     components:
     - type: Transform
       pos: -2.5,-6.5
       parent: 1
-  - uid: 512
+  - uid: 646
     components:
     - type: Transform
       pos: 8.5,-6.5
       parent: 1
-  - uid: 513
+  - uid: 647
     components:
     - type: Transform
       pos: -3.5,-9.5
       parent: 1
-  - uid: 514
+  - uid: 648
     components:
     - type: Transform
       pos: 9.5,-9.5
       parent: 1
-  - uid: 515
+  - uid: 649
     components:
     - type: Transform
       pos: -2.5,5.5
       parent: 1
-  - uid: 516
+  - uid: 650
     components:
     - type: Transform
       pos: -2.5,6.5
       parent: 1
-  - uid: 517
+  - uid: 651
     components:
     - type: Transform
       pos: 8.5,6.5
       parent: 1
-  - uid: 518
+  - uid: 652
     components:
     - type: Transform
       pos: 8.5,5.5
       parent: 1
-  - uid: 519
+  - uid: 653
     components:
     - type: Transform
       pos: -1.5,7.5
       parent: 1
-  - uid: 520
+  - uid: 654
     components:
     - type: Transform
       pos: 7.5,7.5
       parent: 1
-  - uid: 521
+  - uid: 655
     components:
     - type: Transform
       pos: -1.5,8.5
       parent: 1
-  - uid: 522
+  - uid: 656
     components:
     - type: Transform
       pos: 7.5,8.5
       parent: 1
-  - uid: 523
+  - uid: 657
     components:
     - type: Transform
       pos: 2.5,11.5
       parent: 1
-  - uid: 524
+  - uid: 658
     components:
     - type: Transform
       pos: 3.5,11.5
       parent: 1
-  - uid: 525
+  - uid: 659
     components:
     - type: Transform
       pos: 7.5,9.5
       parent: 1
-  - uid: 526
+  - uid: 660
     components:
     - type: Transform
       pos: -1.5,9.5
       parent: 1
-  - uid: 527
+  - uid: 661
     components:
     - type: Transform
       pos: 3.5,-21.5
       parent: 1
-  - uid: 528
+  - uid: 662
     components:
     - type: Transform
       pos: 9.5,-11.5
       parent: 1
-  - uid: 529
+  - uid: 663
     components:
     - type: Transform
       pos: -3.5,-11.5
       parent: 1
-  - uid: 530
+  - uid: 664
     components:
     - type: Transform
       pos: 9.5,-15.5
       parent: 1
-  - uid: 531
+  - uid: 665
     components:
     - type: Transform
       pos: -3.5,-15.5
       parent: 1
-  - uid: 532
+  - uid: 666
     components:
     - type: Transform
       pos: 0.5,-21.5
       parent: 1
-  - uid: 533
+  - uid: 667
     components:
     - type: Transform
       pos: 6.5,-20.5
       parent: 1
-  - uid: 534
+  - uid: 668
     components:
     - type: Transform
       pos: 6.5,-21.5
       parent: 1
-  - uid: 535
+  - uid: 669
     components:
     - type: Transform
       pos: 1.5,-21.5
       parent: 1
-  - uid: 536
+  - uid: 670
     components:
     - type: Transform
       pos: -0.5,-20.5
       parent: 1
-  - uid: 537
+  - uid: 671
     components:
     - type: Transform
       pos: 2.5,-21.5
       parent: 1
-  - uid: 538
+  - uid: 672
     components:
     - type: Transform
       pos: -0.5,-21.5
       parent: 1
-  - uid: 539
+  - uid: 673
     components:
     - type: Transform
       pos: 4.5,-21.5
       parent: 1
-  - uid: 540
+  - uid: 674
     components:
     - type: Transform
       pos: 5.5,-21.5
       parent: 1
-  - uid: 541
+  - uid: 675
     components:
     - type: Transform
       pos: -0.5,-19.5
       parent: 1
-  - uid: 542
+  - uid: 676
     components:
     - type: Transform
       pos: 6.5,-19.5
       parent: 1
-  - uid: 543
+  - uid: 677
     components:
     - type: Transform
       pos: -3.5,-8.5
       parent: 1
-  - uid: 544
+  - uid: 678
     components:
     - type: Transform
       pos: 9.5,-8.5
       parent: 1
-  - uid: 545
+  - uid: 679
     components:
     - type: Transform
       pos: 0.5,-22.5
       parent: 1
-  - uid: 546
+  - uid: 680
     components:
     - type: Transform
       pos: 5.5,-22.5
       parent: 1
-  - uid: 547
+  - uid: 681
     components:
     - type: Transform
       pos: -1.5,-19.5
       parent: 1
-  - uid: 548
+  - uid: 682
     components:
     - type: Transform
       pos: 7.5,-19.5
       parent: 1
-  - uid: 549
+  - uid: 683
     components:
     - type: Transform
       pos: 8.5,-19.5
       parent: 1
-  - uid: 550
+  - uid: 684
     components:
     - type: Transform
       pos: -2.5,-19.5
       parent: 1
-  - uid: 551
+  - uid: 685
     components:
     - type: Transform
       pos: -2.5,-16.5
       parent: 1
-  - uid: 552
+  - uid: 686
     components:
     - type: Transform
       pos: 8.5,-18.5
       parent: 1
-  - uid: 553
+  - uid: 687
     components:
     - type: Transform
       pos: -2.5,-17.5
       parent: 1
-  - uid: 554
+  - uid: 688
     components:
     - type: Transform
       pos: 8.5,-16.5
       parent: 1
-  - uid: 555
+  - uid: 689
     components:
     - type: Transform
       pos: 8.5,-17.5
       parent: 1
-  - uid: 556
+  - uid: 690
     components:
     - type: Transform
       pos: -2.5,-18.5
       parent: 1
-  - uid: 557
+  - uid: 691
     components:
     - type: Transform
       pos: -3.5,-18.5
       parent: 1
-  - uid: 558
+  - uid: 692
     components:
     - type: Transform
       pos: 9.5,-18.5
       parent: 1
-  - uid: 559
+  - uid: 693
     components:
     - type: Transform
       pos: -3.5,-19.5
       parent: 1
-  - uid: 560
+  - uid: 694
     components:
     - type: Transform
       pos: 9.5,-19.5
       parent: 1
 - proto: WallReinforcedDiagonal
   entities:
-  - uid: 561
+  - uid: 695
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-11.5
       parent: 1
-  - uid: 562
+  - uid: 696
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 8.5,-11.5
       parent: 1
-  - uid: 563
+  - uid: 697
     components:
     - type: Transform
       pos: 0.5,1.5
       parent: 1
-  - uid: 564
+  - uid: 698
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,1.5
       parent: 1
-  - uid: 565
+  - uid: 699
     components:
     - type: Transform
       pos: -0.5,4.5
       parent: 1
-  - uid: 566
+  - uid: 700
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,4.5
       parent: 1
-  - uid: 567
+  - uid: 701
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,3.5
       parent: 1
-  - uid: 568
+  - uid: 702
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,3.5
       parent: 1
-  - uid: 569
+  - uid: 703
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,-7.5
       parent: 1
-  - uid: 570
+  - uid: 704
     components:
     - type: Transform
       pos: -0.5,-7.5
       parent: 1
-  - uid: 571
+  - uid: 705
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,-5.5
       parent: 1
-  - uid: 572
+  - uid: 706
     components:
     - type: Transform
       pos: -2.5,-5.5
       parent: 1
-  - uid: 573
+  - uid: 707
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,0.5
       parent: 1
-  - uid: 574
+  - uid: 708
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,0.5
       parent: 1
-  - uid: 575
+  - uid: 709
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,6.5
       parent: 1
-  - uid: 576
+  - uid: 710
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,6.5
       parent: 1
-  - uid: 577
+  - uid: 711
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,7.5
       parent: 1
-  - uid: 578
+  - uid: 712
     components:
     - type: Transform
       pos: -2.5,7.5
       parent: 1
-  - uid: 579
+  - uid: 713
     components:
     - type: Transform
       pos: -1.5,10.5
       parent: 1
-  - uid: 580
+  - uid: 714
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,10.5
       parent: 1
-  - uid: 581
+  - uid: 715
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-22.5
       parent: 1
-  - uid: 582
+  - uid: 716
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-22.5
       parent: 1
-  - uid: 583
+  - uid: 717
     components:
     - type: Transform
       pos: 8.5,-15.5
       parent: 1
-  - uid: 584
+  - uid: 718
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-15.5
       parent: 1
-  - uid: 585
+  - uid: 719
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,-20.5
       parent: 1
-  - uid: 586
+  - uid: 720
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4791,213 +4840,213 @@ entities:
       parent: 1
 - proto: WallSolid
   entities:
-  - uid: 587
+  - uid: 721
     components:
     - type: Transform
       pos: 4.5,-12.5
       parent: 1
-  - uid: 588
+  - uid: 722
     components:
     - type: Transform
       pos: 3.5,-12.5
       parent: 1
-  - uid: 589
+  - uid: 723
     components:
     - type: Transform
       pos: 2.5,-12.5
       parent: 1
-  - uid: 590
+  - uid: 724
     components:
     - type: Transform
       pos: 1.5,-12.5
       parent: 1
-  - uid: 591
+  - uid: 725
     components:
     - type: Transform
       pos: 4.5,-0.5
       parent: 1
-  - uid: 592
+  - uid: 726
     components:
     - type: Transform
       pos: 1.5,-0.5
       parent: 1
-  - uid: 593
+  - uid: 727
     components:
     - type: Transform
       pos: 1.5,-4.5
       parent: 1
-  - uid: 594
+  - uid: 728
     components:
     - type: Transform
       pos: 4.5,-4.5
       parent: 1
-  - uid: 595
+  - uid: 729
     components:
     - type: Transform
       pos: -0.5,9.5
       parent: 1
-  - uid: 596
+  - uid: 730
     components:
     - type: Transform
       pos: 6.5,9.5
       parent: 1
-  - uid: 597
+  - uid: 731
     components:
     - type: Transform
       pos: -0.5,8.5
       parent: 1
-  - uid: 598
+  - uid: 732
     components:
     - type: Transform
       pos: 6.5,8.5
       parent: 1
-  - uid: 599
+  - uid: 733
     components:
     - type: Transform
       pos: -0.5,-10.5
       parent: 1
-  - uid: 600
+  - uid: 734
     components:
     - type: Transform
       pos: 0.5,7.5
       parent: 1
-  - uid: 601
+  - uid: 735
     components:
     - type: Transform
       pos: -0.5,7.5
       parent: 1
-  - uid: 602
+  - uid: 736
     components:
     - type: Transform
       pos: 1.5,7.5
       parent: 1
-  - uid: 603
+  - uid: 737
     components:
     - type: Transform
       pos: 4.5,7.5
       parent: 1
-  - uid: 604
+  - uid: 738
     components:
     - type: Transform
       pos: 5.5,7.5
       parent: 1
-  - uid: 605
+  - uid: 739
     components:
     - type: Transform
       pos: 6.5,7.5
       parent: 1
-  - uid: 606
+  - uid: 740
     components:
     - type: Transform
       pos: 6.5,-10.5
       parent: 1
-  - uid: 607
+  - uid: 741
     components:
     - type: Transform
       pos: 0.5,-11.5
       parent: 1
-  - uid: 608
+  - uid: 742
     components:
     - type: Transform
       pos: 5.5,-11.5
       parent: 1
-  - uid: 609
+  - uid: 743
     components:
     - type: Transform
       pos: 5.5,-12.5
       parent: 1
-  - uid: 610
+  - uid: 744
     components:
     - type: Transform
       pos: 0.5,-12.5
       parent: 1
-  - uid: 611
+  - uid: 745
     components:
     - type: Transform
       pos: 5.5,-15.5
       parent: 1
-  - uid: 612
+  - uid: 746
     components:
     - type: Transform
       pos: 0.5,-16.5
       parent: 1
-  - uid: 613
+  - uid: 747
     components:
     - type: Transform
       pos: 0.5,-15.5
       parent: 1
-  - uid: 614
+  - uid: 748
     components:
     - type: Transform
       pos: 5.5,-16.5
       parent: 1
-  - uid: 615
+  - uid: 749
     components:
     - type: Transform
       pos: 6.5,-16.5
       parent: 1
-  - uid: 616
+  - uid: 750
     components:
     - type: Transform
       pos: -0.5,-16.5
       parent: 1
-  - uid: 617
+  - uid: 751
     components:
     - type: Transform
       pos: -0.5,-17.5
       parent: 1
-  - uid: 618
+  - uid: 752
     components:
     - type: Transform
       pos: 6.5,-17.5
       parent: 1
-  - uid: 619
+  - uid: 753
     components:
     - type: Transform
       pos: 6.5,-18.5
       parent: 1
-  - uid: 620
+  - uid: 754
     components:
     - type: Transform
       pos: 1.5,-2.5
       parent: 1
-  - uid: 621
+  - uid: 755
     components:
     - type: Transform
       pos: 4.5,-2.5
       parent: 1
 - proto: WallSolidDiagonal
   entities:
-  - uid: 622
+  - uid: 756
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-8.5
       parent: 1
-  - uid: 623
+  - uid: 757
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,-8.5
       parent: 1
-  - uid: 624
+  - uid: 758
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-10.5
       parent: 1
-  - uid: 625
+  - uid: 759
     components:
     - type: Transform
       pos: 5.5,-10.5
       parent: 1
-  - uid: 626
+  - uid: 760
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-11.5
       parent: 1
-  - uid: 627
+  - uid: 761
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -5005,43 +5054,43 @@ entities:
       parent: 1
 - proto: WarningWaste
   entities:
-  - uid: 628
+  - uid: 762
     components:
     - type: Transform
       pos: 0.5,-6.5
       parent: 1
-  - uid: 629
+  - uid: 763
     components:
     - type: Transform
       pos: 0.5,-4.5
       parent: 1
-  - uid: 630
+  - uid: 764
     components:
     - type: Transform
       pos: 0.5,-2.5
       parent: 1
-  - uid: 631
+  - uid: 765
     components:
     - type: Transform
       pos: 0.5,-0.5
       parent: 1
 - proto: WarpPoint
   entities:
-  - uid: 632
+  - uid: 766
     components:
     - type: Transform
       pos: 2.5,-1.5
       parent: 1
 - proto: WaterCooler
   entities:
-  - uid: 633
+  - uid: 767
     components:
     - type: Transform
       pos: 1.5,-7.5
       parent: 1
 - proto: WeaponCapacitorRecharger
   entities:
-  - uid: 634
+  - uid: 768
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5049,7 +5098,7 @@ entities:
       parent: 1
 - proto: WindoorSecure
   entities:
-  - uid: 635
+  - uid: 769
     components:
     - type: Transform
       rot: 3.141592653589793 rad


### PR DESCRIPTION


## About the PR
Fixed the unspaced tiles in the gas chambers
Air alarm added & connected for chamber sensors
Tiles underneath chamber windows removed

## Why / Balance
Vacuum tiles weren't applied, need the chambers to be empty

## Technical details

## How to test
Check inside the chambers with a gas analyzer to ensure they are spaced properly
See Air alarm top right in the spaced area

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes


**Changelog**
add: Harvester tweak (Improper chamber spacing, air alarm, tiled windows)
