### PR TITLE
Clown Admeme npc lootbox fixes

### DIFF
--- a/Resources/Prototypes/_AS/Catalog/Fills/Backpacks/npc_loot_clowns.yml
+++ b/Resources/Prototypes/_AS/Catalog/Fills/Backpacks/npc_loot_clowns.yml
@@ -10,6 +10,11 @@
   - type: Sprite
     sprite: Clothing/Back/Duffels/mime.rsi
     state: icon
+  - type: SpawnItemsOnUse
+    items:
+      - id: SpaceCash10
+    sound:
+      path: /Audio/Items/jumpsuit_equip.ogg
 
 - type: entity
   parent: ClownDuffelGiftBox
@@ -28,9 +33,6 @@
     # Weapon
     - id: NFRevolverCapGunFake
       prob: 0.5
-    - id: SpeedLoaderMagnum
-    - id: SpeedLoaderMagnum
-      prob: 0.6
     # Items
     - id: MimePowersImplanter
       prob: 0.1
@@ -91,7 +93,7 @@
       prob: 0.7
     # Items
     - id: FoodPieBananaCream
-      prob: 0.05
+      prob: 0.8
     - id: FoodPieBananaCream
       prob: 0.05
     - id: FoodPieBananaCream
@@ -109,7 +111,7 @@
   - type: SpawnItemsOnUse
     items:
     - id: SpaceCash1000
-      prob: 0.2
+      prob: 1
     - id: CluwneHorn
       prob: 0.05
     sound:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixes the bag spawn of a specific clown npc from the clown npc admeme list 

## Why / Balance
A bag would open infinitely and allow for infinite money 

## Technical details
Removed some ammo drops

## How to test
Spawn a twisted mime, open its bag, see that it doesn't open infinitely 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**

:cl:
- fix: Fixed an ammo bag opening infinitely 

