### PR TITLE
Lock Chemvend Ships Behind Medical Access

### DIFF
--- a/Resources/Prototypes/_NF/Shipyard/caladrius.yml
+++ b/Resources/Prototypes/_NF/Shipyard/caladrius.yml
@@ -17,6 +17,7 @@
   price: 200000 # 133217 0.5 199825.5
   category: Large
   group: Medical
+  access: Medical # Aurora
   shuttlePath: /Maps/_NF/Shuttles/caladrius.yml
   guidebookPage: ShipyardCaladrius
   class:

--- a/Resources/Prototypes/_NF/Shipyard/eagle.yml
+++ b/Resources/Prototypes/_NF/Shipyard/eagle.yml
@@ -12,6 +12,7 @@
   price: 62500 # 52038 0.2 62445.6
   category: Medium
   group: Medical
+  access: Medical # Aurora
   shuttlePath: /Maps/_NF/Shuttles/eagle.yml
   guidebookPage: ShipyardEagle
   class:

--- a/Resources/Prototypes/_NF/Shipyard/vitalis.yml
+++ b/Resources/Prototypes/_NF/Shipyard/vitalis.yml
@@ -6,6 +6,7 @@
   price: 75000 #62702 0.2 75242.4
   category: Medium
   group: Medical
+  access: Medical # Aurora
   shuttlePath: /Maps/_NF/Shuttles/vitalis.yml
   guidebookPage: ShipyardVitalis
   class:


### PR DESCRIPTION

## About the PR
Puts access locks on the shipyard entries for the eagle, vitalis, and caldrius
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Chemvend ships should be locked behind medical access especially with how chem-kits are available from cargo. 
## Technical details
<!-- Summary of code changes for easier review. -->
Added access checks to three ships
## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
Spawn as merc and weep as you cannot buy eagle, vitalis, or caldrius 
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Put access locks on ships with chemvends

