### PR TITLE
Add Inheritance to Markings

### DIFF
--- a/Content.Shared/Humanoid/Markings/MarkingPrototype.cs
+++ b/Content.Shared/Humanoid/Markings/MarkingPrototype.cs
@@ -1,23 +1,24 @@
 using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Array; // AS - Marking Inheritance
 using Robust.Shared.Utility;
 
 namespace Content.Shared.Humanoid.Markings
 {
     [Prototype]
-    // DEN: Make markings inheriting (IInheritingPrototype)
+    // AS: Make markings inheriting (IInheritingPrototype)
     public sealed partial class MarkingPrototype : IPrototype, IInheritingPrototype
     {
         [IdDataField]
         public string ID { get; private set; } = "uwu";
 
-        // DEN: Make markings inheriting
+        // AS: Make markings inheriting
         [ParentDataField(typeof(AbstractPrototypeIdArraySerializer<MarkingPrototype>))]
         public string[]? Parents { get; }
 
         [NeverPushInheritance]
         [AbstractDataField]
         public bool Abstract { get; }
-        // End DEN
+        // End AS
 
         public string Name { get; private set; } = default!;
 

--- a/Content.Shared/Humanoid/Markings/MarkingPrototype.cs
+++ b/Content.Shared/Humanoid/Markings/MarkingPrototype.cs
@@ -23,24 +23,32 @@ namespace Content.Shared.Humanoid.Markings
         public string Name { get; private set; } = default!;
 
         [DataField("bodyPart", required: true)]
-        public HumanoidVisualLayers BodyPart { get; private set; } = default!;
+        public HumanoidVisualLayers BodyPart { get; private set; }
 
         [DataField("markingCategory", required: true)]
-        public MarkingCategories MarkingCategory { get; private set; } = default!;
+        public MarkingCategories MarkingCategory { get; private set; }
 
-        [DataField("speciesRestriction")]
+        [DataField]
         public List<string>? SpeciesRestrictions { get; private set; }
 
-        [DataField("sexRestriction")]
+        // DEN - Invert marking restrictions
+        [DataField]
+        public bool InvertSpeciesRestriction { get; private set; }
+
+        [DataField]
         public Sex? SexRestriction { get; private set; }
 
-        [DataField("followSkinColor")]
-        public bool FollowSkinColor { get; private set; } = false;
+        // DEN - Invert marking restrictions
+        [DataField]
+        public bool InvertSexRestriction { get; private set; }
 
-        [DataField("forcedColoring")]
-        public bool ForcedColoring { get; private set; } = false;
+        [DataField]
+        public bool FollowSkinColor { get; private set; }
 
-        [DataField("coloring")]
+        [DataField]
+        public bool ForcedColoring { get; private set; }
+
+        [DataField]
         public MarkingColors Coloring { get; private set; } = new();
 
         /// <summary>

--- a/Content.Shared/Humanoid/Markings/MarkingPrototype.cs
+++ b/Content.Shared/Humanoid/Markings/MarkingPrototype.cs
@@ -4,10 +4,20 @@ using Robust.Shared.Utility;
 namespace Content.Shared.Humanoid.Markings
 {
     [Prototype]
-    public sealed partial class MarkingPrototype : IPrototype
+    // DEN: Make markings inheriting (IInheritingPrototype)
+    public sealed partial class MarkingPrototype : IPrototype, IInheritingPrototype
     {
         [IdDataField]
         public string ID { get; private set; } = "uwu";
+
+        // DEN: Make markings inheriting
+        [ParentDataField(typeof(AbstractPrototypeIdArraySerializer<MarkingPrototype>))]
+        public string[]? Parents { get; }
+
+        [NeverPushInheritance]
+        [AbstractDataField]
+        public bool Abstract { get; }
+        // End DEN
 
         public string Name { get; private set; } = default!;
 
@@ -43,8 +53,8 @@ namespace Content.Shared.Humanoid.Markings
         public List<SpriteSpecifier> Sprites { get; private set; } = default!;
 
         // impstation edit - allow markings to support shaders
-		[DataField("shader")]
-		public string? Shader { get; private set; } = null;
+        [DataField("shader")]
+        public string? Shader { get; private set; } = null;
         // end impstation edit
         public Marking AsMarking()
         {

--- a/Content.Shared/Humanoid/Markings/MarkingPrototype.cs
+++ b/Content.Shared/Humanoid/Markings/MarkingPrototype.cs
@@ -1,24 +1,24 @@
 using Robust.Shared.Prototypes;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Array; // AS - Marking Inheritance
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Array; // AuroraSong
 using Robust.Shared.Utility;
 
 namespace Content.Shared.Humanoid.Markings
 {
     [Prototype]
-    // AS: Make markings inheriting (IInheritingPrototype)
+    // AuroraSong: Make markings inheriting (IInheritingPrototype)
     public sealed partial class MarkingPrototype : IPrototype, IInheritingPrototype
     {
         [IdDataField]
         public string ID { get; private set; } = "uwu";
 
-        // AS: Make markings inheriting
+        // AuroraSong: Make markings inheriting
         [ParentDataField(typeof(AbstractPrototypeIdArraySerializer<MarkingPrototype>))]
         public string[]? Parents { get; }
 
         [NeverPushInheritance]
         [AbstractDataField]
         public bool Abstract { get; }
-        // End AS
+        // End AuroraSong
 
         public string Name { get; private set; } = default!;
 

--- a/Content.Shared/Humanoid/Markings/MarkingPrototype.cs
+++ b/Content.Shared/Humanoid/Markings/MarkingPrototype.cs
@@ -28,7 +28,7 @@ namespace Content.Shared.Humanoid.Markings
         [DataField("markingCategory", required: true)]
         public MarkingCategories MarkingCategory { get; private set; }
 
-        [DataField]
+        [DataField("speciesRestriction")]
         public List<string>? SpeciesRestrictions { get; private set; }
 
         // DEN - Invert marking restrictions

--- a/Content.Shared/Humanoid/Markings/MarkingsSet.cs
+++ b/Content.Shared/Humanoid/Markings/MarkingsSet.cs
@@ -169,8 +169,8 @@ public sealed partial class MarkingSet
                     toRemove.Add((category, marking.MarkingId));
                 }
 
-                if (prototype.SpeciesRestrictions != null
-                    && !prototype.SpeciesRestrictions.Contains(species))
+                // DEN - Invert marking restrictions
+                if (!markingManager.IsSpeciesWhitelisted(species, prototype))
                 {
                     toRemove.Add((category, marking.MarkingId));
                 }
@@ -189,7 +189,7 @@ public sealed partial class MarkingSet
             {
                 foreach (var marking in list)
                 {
-                    if (markingManager.TryGetMarking(marking, out var prototype)) // Frontier: modified this test to add forced marking test 
+                    if (markingManager.TryGetMarking(marking, out var prototype)) // Frontier: modified this test to add forced marking test
                     {
                         if (markingManager.MustMatchSkin(species, prototype.BodyPart, out var alpha, prototypeManager))
                             marking.SetColor(skinColor.Value.WithAlpha(alpha));
@@ -222,10 +222,9 @@ public sealed partial class MarkingSet
                     continue;
                 }
 
-                if (prototype.SexRestriction != null && prototype.SexRestriction != sex)
-                {
+                // DEN - Invert marking restrictions
+                if (!markingManager.IsSexWhitelisted(sex, prototype))
                     toRemove.Add((category, marking.MarkingId));
-                }
             }
         }
 

--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/tattoos.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/tattoos.yml
@@ -1,167 +1,101 @@
 - type: marking
+  parent: [BaseTattoo, BaseSpeciesChestStandardOrganic] # AS: Marking inheritance
   id: TattooHiveChest
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [Human, Dwarf, Goblin, Sheleg, Felinid, Oni, Harpy] # Frontier: added Goblin and afterwards
-  coloring:
-    default:
-      type:
-        !type:TattooColoring
-      fallbackColor: "#666666"
   sprites:
   - sprite: Mobs/Customization/tattoos.rsi
     state: tattoo_hive_chest
 
 - type: marking
+  parent: [BaseTattoo, BaseSpeciesChestStandardOrganic] # AS: Marking inheritance
   id: TattooNightlingChest
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [Human, Dwarf, Goblin, Sheleg, Felinid, Oni, Harpy] # Frontier: added Goblin and afterwards
-  coloring:
-    default:
-      type:
-        !type:TattooColoring
-      fallbackColor: "#666666"
   sprites:
   - sprite: Mobs/Customization/tattoos.rsi
     state: tattoo_nightling
 
 - type: marking
+  parent: [BaseTattoo, BaseSpeciesLegsStandardOrganic] # AS: Marking inheritance
   id: TattooSilverburghLeftLeg
   bodyPart: LLeg
   markingCategory: Legs
-  speciesRestriction: [Human, Dwarf, Goblin, Sheleg, Felinid, Oni, Harpy] # Frontier: added Goblin and afterwards
-  coloring:
-    default:
-      type:
-        !type:TattooColoring
-      fallbackColor: "#666666"
   sprites:
   - sprite: Mobs/Customization/tattoos.rsi
     state: tattoo_silverburgh_l_leg
 
 - type: marking
+  parent: [BaseTattoo, BaseSpeciesLegsStandardOrganic] # AS: Marking inheritance
   id: TattooSilverburghRightLeg
   bodyPart: RLeg
   markingCategory: Legs
-  speciesRestriction: [Human, Dwarf, Goblin, Sheleg, Felinid, Oni, Harpy] # Frontier: added Goblin and afterwards
-  coloring:
-    default:
-      type:
-        !type:TattooColoring
-      fallbackColor: "#666666"
   sprites:
   - sprite: Mobs/Customization/tattoos.rsi
     state: tattoo_silverburgh_r_leg
 
 - type: marking
+  parent: [BaseTattoo, BaseSpeciesArmsStandardOrganic] # AS: Marking inheritance
   id: TattooCampbellLeftArm
   bodyPart: LArm
   markingCategory: Arms
-  speciesRestriction: [Human, Dwarf, Goblin, Sheleg, Felinid, Oni, Harpy] # Frontier: added Goblin and afterwards
-  coloring:
-    default:
-      type:
-        !type:TattooColoring
-      fallbackColor: "#666666"
   sprites:
   - sprite: Mobs/Customization/tattoos.rsi
     state: tattoo_campbell_l_arm
 
 - type: marking
+  parent: [BaseTattoo, BaseSpeciesArmsStandardOrganic] # AS: Marking inheritance
   id: TattooCampbellRightArm
   bodyPart: RArm
   markingCategory: Arms
-  speciesRestriction: [Human, Dwarf, Goblin, Sheleg, Felinid, Oni, Harpy] # Frontier: added Goblin and afterwards
-  coloring:
-    default:
-      type:
-        !type:TattooColoring
-      fallbackColor: "#666666"
   sprites:
   - sprite: Mobs/Customization/tattoos.rsi
     state: tattoo_campbell_r_arm
 
 - type: marking
+  parent: [BaseTattoo, BaseSpeciesLegsStandardOrganic] # AS: Marking inheritance
   id: TattooCampbellLeftLeg
   bodyPart: LLeg
   markingCategory: Legs
-  speciesRestriction: [Human, Dwarf, Goblin, Sheleg, Felinid, Oni, Harpy] # Frontier: added Goblin and afterwards
-  coloring:
-    default:
-      type:
-        !type:TattooColoring
-      fallbackColor: "#666666"
   sprites:
   - sprite: Mobs/Customization/tattoos.rsi
     state: tattoo_campbell_l_leg
 
 - type: marking
+  parent: [BaseTattoo, BaseSpeciesLegsStandardOrganic] # AS: Marking inheritance
   id: TattooCampbellRightLeg
   bodyPart: RLeg
   markingCategory: Legs
-  speciesRestriction: [Human, Dwarf, Goblin, Sheleg, Felinid, Oni, Harpy] # Frontier: added Goblin and afterwards
-  coloring:
-    default:
-      type:
-        !type:TattooColoring
-      fallbackColor: "#666666"
   sprites:
   - sprite: Mobs/Customization/tattoos.rsi
     state: tattoo_campbell_r_leg
 
 - type: marking
+  parent: [BaseEyes, BaseSpeciesEyesStandard] # AS: Marking inheritance
   id: TattooEyeRight
-  bodyPart: Eyes
-  markingCategory: Head
-  speciesRestriction: [Human, SlimePerson, Reptilian, Dwarf, Goblin, Sheleg, Felinid, Oni, Harpy, Rodentia, Feroxi, Vulpkanin] # Delta V - Felinid, Oni, Harpy, Rodentia; Funky - Vulpkanin
-  coloring:
-    default:
-      type:
-        !type:EyeColoring
-          negative: true
   sprites:
   - sprite: Mobs/Customization/tattoos.rsi
     state: tattoo_eye_r
 
 - type: marking
+  parent: [BaseEyes, BaseSpeciesEyesStandard] # AS: Marking inheritance
   id: TattooEyeLeft
-  bodyPart: Eyes
-  markingCategory: Head
-  speciesRestriction: [Human, SlimePerson, Reptilian, Dwarf, Goblin, Sheleg, Felinid, Oni, Harpy, Rodentia, Feroxi, Vulpkanin] # Delta V - Felinid, Oni, Harpy, Rodentia; Funky - Vulpkanin
-  coloring:
-    default:
-      type:
-        !type:EyeColoring
-          negative: true
   sprites:
   - sprite: Mobs/Customization/tattoos.rsi
     state: tattoo_eye_l
 
 - type: marking
+  parent: [BaseEyes, BaseSpeciesMoth] # AS: Marking inheritance
   id: TattooEyeMothRight
-  bodyPart: Eyes
   markingCategory: Overlay
-  speciesRestriction: [Moth]
-  coloring:
-    default:
-      type:
-        !type:EyeColoring
-          negative: true
   sprites:
   - sprite: Mobs/Customization/tattoos.rsi
     state: tattoo_eye_moth_r
 
 - type: marking
+  parent: [BaseEyes, BaseSpeciesMoth] # AS: Marking inheritance
   id: TattooEyeMothLeft
-  bodyPart: Eyes
   markingCategory: Overlay
-  speciesRestriction: [Moth]
-  coloring:
-    default:
-      type:
-        !type:EyeColoring
-          negative: true
   sprites:
   - sprite: Mobs/Customization/tattoos.rsi
     state: tattoo_eye_moth_l

--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/tattoos.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/tattoos.yml
@@ -1,5 +1,5 @@
 - type: marking
-  parent: [BaseTattoo, BaseSpeciesChestStandardOrganic] # AS: Marking inheritance
+  parent: [BaseTattoo, BaseSpeciesChestStandardOrganic] # AuroraSong: Marking inheritance
   id: TattooHiveChest
   bodyPart: Chest
   markingCategory: Chest
@@ -8,7 +8,7 @@
     state: tattoo_hive_chest
 
 - type: marking
-  parent: [BaseTattoo, BaseSpeciesChestStandardOrganic] # AS: Marking inheritance
+  parent: [BaseTattoo, BaseSpeciesChestStandardOrganic] # AuroraSong: Marking inheritance
   id: TattooNightlingChest
   bodyPart: Chest
   markingCategory: Chest
@@ -17,7 +17,7 @@
     state: tattoo_nightling
 
 - type: marking
-  parent: [BaseTattoo, BaseSpeciesLegsStandardOrganic] # AS: Marking inheritance
+  parent: [BaseTattoo, BaseSpeciesLegsStandardOrganic] # AuroraSong: Marking inheritance
   id: TattooSilverburghLeftLeg
   bodyPart: LLeg
   markingCategory: Legs
@@ -26,7 +26,7 @@
     state: tattoo_silverburgh_l_leg
 
 - type: marking
-  parent: [BaseTattoo, BaseSpeciesLegsStandardOrganic] # AS: Marking inheritance
+  parent: [BaseTattoo, BaseSpeciesLegsStandardOrganic] # AuroraSong: Marking inheritance
   id: TattooSilverburghRightLeg
   bodyPart: RLeg
   markingCategory: Legs
@@ -35,7 +35,7 @@
     state: tattoo_silverburgh_r_leg
 
 - type: marking
-  parent: [BaseTattoo, BaseSpeciesArmsStandardOrganic] # AS: Marking inheritance
+  parent: [BaseTattoo, BaseSpeciesArmsStandardOrganic] # AuroraSong: Marking inheritance
   id: TattooCampbellLeftArm
   bodyPart: LArm
   markingCategory: Arms
@@ -44,7 +44,7 @@
     state: tattoo_campbell_l_arm
 
 - type: marking
-  parent: [BaseTattoo, BaseSpeciesArmsStandardOrganic] # AS: Marking inheritance
+  parent: [BaseTattoo, BaseSpeciesArmsStandardOrganic] # AuroraSong: Marking inheritance
   id: TattooCampbellRightArm
   bodyPart: RArm
   markingCategory: Arms
@@ -53,7 +53,7 @@
     state: tattoo_campbell_r_arm
 
 - type: marking
-  parent: [BaseTattoo, BaseSpeciesLegsStandardOrganic] # AS: Marking inheritance
+  parent: [BaseTattoo, BaseSpeciesLegsStandardOrganic] # AuroraSong: Marking inheritance
   id: TattooCampbellLeftLeg
   bodyPart: LLeg
   markingCategory: Legs
@@ -62,7 +62,7 @@
     state: tattoo_campbell_l_leg
 
 - type: marking
-  parent: [BaseTattoo, BaseSpeciesLegsStandardOrganic] # AS: Marking inheritance
+  parent: [BaseTattoo, BaseSpeciesLegsStandardOrganic] # AuroraSong: Marking inheritance
   id: TattooCampbellRightLeg
   bodyPart: RLeg
   markingCategory: Legs
@@ -71,21 +71,21 @@
     state: tattoo_campbell_r_leg
 
 - type: marking
-  parent: [BaseEyes, BaseSpeciesEyesStandard] # AS: Marking inheritance
+  parent: [BaseEyes, BaseSpeciesEyesStandard] # AuroraSong: Marking inheritance
   id: TattooEyeRight
   sprites:
   - sprite: Mobs/Customization/tattoos.rsi
     state: tattoo_eye_r
 
 - type: marking
-  parent: [BaseEyes, BaseSpeciesEyesStandard] # AS: Marking inheritance
+  parent: [BaseEyes, BaseSpeciesEyesStandard] # AuroraSong: Marking inheritance
   id: TattooEyeLeft
   sprites:
   - sprite: Mobs/Customization/tattoos.rsi
     state: tattoo_eye_l
 
 - type: marking
-  parent: [BaseEyes, BaseSpeciesMoth] # AS: Marking inheritance
+  parent: [BaseEyes, BaseSpeciesMoth] # AuroraSong: Marking inheritance
   id: TattooEyeMothRight
   markingCategory: Overlay
   sprites:
@@ -93,7 +93,7 @@
     state: tattoo_eye_moth_r
 
 - type: marking
-  parent: [BaseEyes, BaseSpeciesMoth] # AS: Marking inheritance
+  parent: [BaseEyes, BaseSpeciesMoth] # AuroraSong: Marking inheritance
   id: TattooEyeMothLeft
   markingCategory: Overlay
   sprites:

--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/vox_tattoos.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/vox_tattoos.yml
@@ -1,55 +1,35 @@
 - type: marking
+  parent: [BaseTattoo, BaseSpeciesVox] # AS: Marking inheritance
   id: TattooVoxHeartLeftArm
   bodyPart: LArm
   markingCategory: Arms
-  speciesRestriction: [Vox]
-  coloring:
-    default:
-      type:
-        !type:TattooColoring
-      fallbackColor: "#666666"
   sprites:
   - sprite: Mobs/Customization/vox_tattoos.rsi
     state: heart_l_arm
 
 - type: marking
+  parent: [BaseTattoo, BaseSpeciesVox] # AS: Marking inheritance
   id: TattooVoxHeartRightArm
   bodyPart: RArm
   markingCategory: Arms
-  speciesRestriction: [Vox]
-  coloring:
-    default:
-      type:
-        !type:TattooColoring
-      fallbackColor: "#666666"
   sprites:
   - sprite: Mobs/Customization/vox_tattoos.rsi
     state: heart_r_arm
 
 - type: marking
+  parent: [BaseTattoo, BaseSpeciesVox] # AS: Marking inheritance
   id: TattooVoxHiveChest
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [Vox]
-  coloring:
-    default:
-      type:
-        !type:TattooColoring
-      fallbackColor: "#666666"
   sprites:
   - sprite: Mobs/Customization/vox_tattoos.rsi
     state: hive_s
 
 - type: marking
+  parent: [BaseTattoo, BaseSpeciesVox] # AS: Marking inheritance
   id: TattooVoxNightlingChest
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [Vox]
-  coloring:
-    default:
-      type:
-        !type:TattooColoring
-      fallbackColor: "#666666"
   sprites:
   - sprite: Mobs/Customization/vox_tattoos.rsi
     state: nightling_s

--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/vox_tattoos.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/vox_tattoos.yml
@@ -1,5 +1,5 @@
 - type: marking
-  parent: [BaseTattoo, BaseSpeciesVox] # AS: Marking inheritance
+  parent: [BaseTattoo, BaseSpeciesVox] # AuroraSong: Marking inheritance
   id: TattooVoxHeartLeftArm
   bodyPart: LArm
   markingCategory: Arms
@@ -8,7 +8,7 @@
     state: heart_l_arm
 
 - type: marking
-  parent: [BaseTattoo, BaseSpeciesVox] # AS: Marking inheritance
+  parent: [BaseTattoo, BaseSpeciesVox] # AuroraSong: Marking inheritance
   id: TattooVoxHeartRightArm
   bodyPart: RArm
   markingCategory: Arms
@@ -17,7 +17,7 @@
     state: heart_r_arm
 
 - type: marking
-  parent: [BaseTattoo, BaseSpeciesVox] # AS: Marking inheritance
+  parent: [BaseTattoo, BaseSpeciesVox] # AuroraSong: Marking inheritance
   id: TattooVoxHiveChest
   bodyPart: Chest
   markingCategory: Chest
@@ -26,7 +26,7 @@
     state: hive_s
 
 - type: marking
-  parent: [BaseTattoo, BaseSpeciesVox] # AS: Marking inheritance
+  parent: [BaseTattoo, BaseSpeciesVox] # AuroraSong: Marking inheritance
   id: TattooVoxNightlingChest
   bodyPart: Chest
   markingCategory: Chest

--- a/Resources/Prototypes/_AS/Entities/Mobs/Customization/Markings/base.yml
+++ b/Resources/Prototypes/_AS/Entities/Mobs/Customization/Markings/base.yml
@@ -1,0 +1,20 @@
+# Markings are inheriting. That means they can have parents now. Yay!
+
+- type: marking
+  abstract: true
+  id: BaseTattoo
+  coloring:
+    default:
+      type: !type:TattooColoring
+      fallbackColor: "#666666"
+
+- type: marking
+  abstract: true
+  id: BaseEyes
+  bodyPart: Eyes
+  markingCategory: Head
+  coloring:
+    default:
+      type:
+        !type:EyeColoring
+          negative: true

--- a/Resources/Prototypes/_AS/Entities/Mobs/Customization/Markings/base_species.yml
+++ b/Resources/Prototypes/_AS/Entities/Mobs/Customization/Markings/base_species.yml
@@ -1,0 +1,97 @@
+# Markings are inheriting. That means they can have parents now. Yay!
+# This file is mostly for species restriction lists.
+# Keep in mind that there is no partial inheritance of species restrictions, so you have to redeclare the entire
+# species restriction list in its entirety for each speciesRestriction property.
+
+# Species for reference, excluding non-roundstart:
+# Arachnid
+# Diona
+# Dwarf
+# Felinid
+# Feroxi
+# Goblin
+# Harpy
+# Human
+# IPC
+# Moth
+# Oni
+# Reptilian
+# Rodentia
+# Sheleg
+# SlimePerson
+# Tajaran
+# Vox
+# Vulpkanin
+
+# "Standard [Body Part]" - Species' whose base body sprites have the same silhouettes / position as humans.
+# Not included are anything where that body part has a different silhouette. If the species has a
+# displacement map that completely changes the way clothes look, like Vox, it probably shoudld be excluded.
+
+- type: marking
+  abstract: true
+  id: BaseSpeciesEyesStandard
+  invertSpeciesRestriction: true
+  speciesRestriction:
+  - Arachnid
+  - Diona
+  - IPC
+  - Moth
+  - Vox
+
+# Organic - Species who can be assumed to have skin. If you can imagine giving this species a tattoo or a scar, it is
+# probably included. (Because this is used for tattoos and scars.)
+
+- type: marking
+  abstract: true
+  id: BaseSpeciesChestStandardOrganic
+  invertSpeciesRestriction: true
+  speciesRestriction:
+  # Non-standard
+  - Moth
+  - Vox
+  # Inorganic / Skinless
+  - Diona
+  - IPC
+
+- type: marking
+  abstract: true
+  id: BaseSpeciesArmsStandardOrganic
+  invertSpeciesRestriction: true
+  speciesRestriction:
+  # Non-standard
+  - Harpy
+  - Moth
+  - Vox
+  # Inorganic / Skinless
+  - Diona
+  - IPC
+
+- type: marking
+  abstract: true
+  id: BaseSpeciesLegsStandardOrganic
+  invertSpeciesRestriction: true
+  speciesRestriction:
+  # Non-standard
+  - Harpy
+  - Moth
+  - Vox
+  # Inorganic / Skinless
+  - Diona
+  - IPC
+  # Technically Tajaran are missing one pixel off the heel (like, very subtle digitigrade)
+  # but I'm not removing them from the legs tattoo list just because of that.
+
+# Non-standard species restrictions.
+# Why single-species restrictions, you ask? I would like to minimize the amount of `speciesRestriction` redeclaration
+# in general. Always easier to edit one prototype than it is to edit potentially dozens. Maybe you add a species that
+# has an identical body but does something different - not that I recommend this.
+
+- type: marking
+  abstract: true
+  id: BaseSpeciesMoth
+  speciesRestriction: [Moth]
+
+- type: marking
+  abstract: true
+  id: BaseSpeciesVox
+  speciesRestriction: [Vox]

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Customization/Markings/tattoos.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Customization/Markings/tattoos.yml
@@ -1,5 +1,5 @@
 - type: marking
-  parent: [BaseTattoo, BaseSpeciesChestStandardOrganic] # AS: Marking inheritance
+  parent: [BaseTattoo, BaseSpeciesChestStandardOrganic] # AuroraSong: Marking inheritance
   id: ChestCutHere
   bodyPart: Chest
   markingCategory: Chest
@@ -8,7 +8,7 @@
     state: chest_cuthere
 
 - type: marking
-  parent: [BaseTattoo, BaseSpeciesArmsStandardOrganic] # AS: Marking inheritance
+  parent: [BaseTattoo, BaseSpeciesArmsStandardOrganic] # AuroraSong: Marking inheritance
   id: ArmDollJointsTattooLeft
   bodyPart: LArm
   markingCategory: Arms
@@ -17,7 +17,7 @@
     state: l_arm_doll
 
 - type: marking
-  parent: [BaseTattoo, BaseSpeciesArmsStandardOrganic] # AS: Marking inheritance
+  parent: [BaseTattoo, BaseSpeciesArmsStandardOrganic] # AuroraSong: Marking inheritance
   id: ArmDollJointsTattooRight
   bodyPart: RArm
   markingCategory: Arms
@@ -26,7 +26,7 @@
     state: r_arm_doll
 
 - type: marking
-  parent: [BaseTattoo, BaseSpeciesArmsStandardOrganic] # AS: Marking inheritance
+  parent: [BaseTattoo, BaseSpeciesArmsStandardOrganic] # AuroraSong: Marking inheritance
   id: HandDollJointsTattooLeft
   bodyPart: LHand
   markingCategory: Arms
@@ -35,7 +35,7 @@
     state: l_hand_doll
 
 - type: marking
-  parent: [BaseTattoo, BaseSpeciesArmsStandardOrganic] # AS: Marking inheritance
+  parent: [BaseTattoo, BaseSpeciesArmsStandardOrganic] # AuroraSong: Marking inheritance
   id: HandDollJointsTattooRight
   bodyPart: RHand
   markingCategory: Arms
@@ -44,7 +44,7 @@
     state: r_hand_doll
 
 - type: marking
-  parent: [BaseTattoo, BaseSpeciesLegsStandardOrganic] # AS: Marking inheritance
+  parent: [BaseTattoo, BaseSpeciesLegsStandardOrganic] # AuroraSong: Marking inheritance
   id: LegDollJointsTattooLeft
   bodyPart: LLeg
   markingCategory: Legs
@@ -53,7 +53,7 @@
     state: l_leg_doll
 
 - type: marking
-  parent: [BaseTattoo, BaseSpeciesLegsStandardOrganic] # AS: Marking inheritance
+  parent: [BaseTattoo, BaseSpeciesLegsStandardOrganic] # AuroraSong: Marking inheritance
   id: LegDollJointsTattooRight
   bodyPart: RLeg
   markingCategory: Legs
@@ -62,7 +62,7 @@
     state: r_leg_doll
 
 - type: marking
-  parent: [BaseTattoo, BaseSpeciesLegsStandardOrganic] # AS: Marking inheritance
+  parent: [BaseTattoo, BaseSpeciesLegsStandardOrganic] # AuroraSong: Marking inheritance
   id: FootDollJointsTattooLeft
   bodyPart: LFoot
   markingCategory: Legs
@@ -71,7 +71,7 @@
     state: l_foot_doll
 
 - type: marking
-  parent: [BaseTattoo, BaseSpeciesLegsStandardOrganic] # AS: Marking inheritance
+  parent: [BaseTattoo, BaseSpeciesLegsStandardOrganic] # AuroraSong: Marking inheritance
   id: FootDollJointsTattooRight
   bodyPart: RFoot
   markingCategory: Legs

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Customization/Markings/tattoos.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Customization/Markings/tattoos.yml
@@ -1,125 +1,80 @@
 - type: marking
+  parent: [BaseTattoo, BaseSpeciesChestStandardOrganic] # AS: Marking inheritance
   id: ChestCutHere
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [Human, Dwarf, Arachnid, SlimePerson, Reptilian, Oni, Goblin, Felinid] # Frontier: add Oni, Goblin, Felinid
-  coloring:
-    default:
-      type:
-        !type:TattooColoring
-      fallbackColor: "#666666"
   sprites:
   - sprite: _Impstation/Mobs/Customization/tattoos.rsi
     state: chest_cuthere
 
 - type: marking
+  parent: [BaseTattoo, BaseSpeciesArmsStandardOrganic] # AS: Marking inheritance
   id: ArmDollJointsTattooLeft
   bodyPart: LArm
   markingCategory: Arms
-  speciesRestriction: [Human, Dwarf, Arachnid, SlimePerson, Reptilian, Oni, Goblin, Felinid] # Frontier: add Oni, Felinid
-  coloring:
-    default:
-      type:
-        !type:TattooColoring
-      fallbackColor: "#666666"
   sprites:
   - sprite: _Impstation/Mobs/Customization/tattoos.rsi
     state: l_arm_doll
 
 - type: marking
+  parent: [BaseTattoo, BaseSpeciesArmsStandardOrganic] # AS: Marking inheritance
   id: ArmDollJointsTattooRight
   bodyPart: RArm
   markingCategory: Arms
-  speciesRestriction: [Human, Dwarf, Arachnid, SlimePerson, Reptilian, Oni, Goblin, Felinid] # Frontier: add Oni, Felinid
-  coloring:
-    default:
-      type:
-        !type:TattooColoring
-      fallbackColor: "#666666"
   sprites:
   - sprite: _Impstation/Mobs/Customization/tattoos.rsi
     state: r_arm_doll
 
 - type: marking
+  parent: [BaseTattoo, BaseSpeciesArmsStandardOrganic] # AS: Marking inheritance
   id: HandDollJointsTattooLeft
   bodyPart: LHand
   markingCategory: Arms
-  speciesRestriction: [Human, Dwarf, Arachnid, SlimePerson, Reptilian, Oni, Goblin, Felinid] # Frontier: add Oni, Felinid
-  coloring:
-    default:
-      type:
-        !type:TattooColoring
-      fallbackColor: "#666666"
   sprites:
   - sprite: _Impstation/Mobs/Customization/tattoos.rsi
     state: l_hand_doll
 
 - type: marking
+  parent: [BaseTattoo, BaseSpeciesArmsStandardOrganic] # AS: Marking inheritance
   id: HandDollJointsTattooRight
   bodyPart: RHand
   markingCategory: Arms
-  speciesRestriction: [Human, Dwarf, Arachnid, SlimePerson, Reptilian, Oni, Goblin, Felinid] # Frontier: add Oni, Felinid
-  coloring:
-    default:
-      type:
-        !type:TattooColoring
-      fallbackColor: "#666666"
   sprites:
   - sprite: _Impstation/Mobs/Customization/tattoos.rsi
     state: r_hand_doll
 
 - type: marking
+  parent: [BaseTattoo, BaseSpeciesLegsStandardOrganic] # AS: Marking inheritance
   id: LegDollJointsTattooLeft
   bodyPart: LLeg
   markingCategory: Legs
-  speciesRestriction: [Human, Dwarf, Arachnid, SlimePerson, Reptilian, Oni, Goblin, Felinid] # Frontier: add Oni, Felinid
-  coloring:
-    default:
-      type:
-        !type:TattooColoring
-      fallbackColor: "#666666"
   sprites:
   - sprite: _Impstation/Mobs/Customization/tattoos.rsi
     state: l_leg_doll
 
 - type: marking
+  parent: [BaseTattoo, BaseSpeciesLegsStandardOrganic] # AS: Marking inheritance
   id: LegDollJointsTattooRight
   bodyPart: RLeg
   markingCategory: Legs
-  speciesRestriction: [Human, Dwarf, Arachnid, SlimePerson, Reptilian, Oni, Goblin, Felinid] # Frontier: add Oni, Felinid
-  coloring:
-    default:
-      type:
-        !type:TattooColoring
-      fallbackColor: "#666666"
   sprites:
   - sprite: _Impstation/Mobs/Customization/tattoos.rsi
     state: r_leg_doll
 
 - type: marking
+  parent: [BaseTattoo, BaseSpeciesLegsStandardOrganic] # AS: Marking inheritance
   id: FootDollJointsTattooLeft
   bodyPart: LFoot
   markingCategory: Legs
-  speciesRestriction: [Human, Dwarf, Arachnid, SlimePerson, Oni, Goblin, Felinid] # Frontier: add Oni, Felinid
-  coloring:
-    default:
-      type:
-        !type:TattooColoring
-      fallbackColor: "#666666"
   sprites:
   - sprite: _Impstation/Mobs/Customization/tattoos.rsi
     state: l_foot_doll
 
 - type: marking
+  parent: [BaseTattoo, BaseSpeciesLegsStandardOrganic] # AS: Marking inheritance
   id: FootDollJointsTattooRight
   bodyPart: RFoot
   markingCategory: Legs
-  speciesRestriction: [Human, Dwarf, Arachnid, SlimePerson, Oni, Goblin, Oni, Goblin, Felinid] # Frontier: add Oni, Goblin, Oni, Felinid
-  coloring:
-    default:
-      type:
-        !type:TattooColoring
-      fallbackColor: "#666666"
   sprites:
   - sprite: _Impstation/Mobs/Customization/tattoos.rsi
     state: r_foot_doll


### PR DESCRIPTION
## About the PR
This PR makes markings an inheritable prototype. To demonstrate this, a bunch of tattoo markings have been given new parent prototypes, which replace their lengthy species restriction lists and their explicit redeclaration of "tattoo" coloration.
 
Also a partial port of TheDenSS14/TheDen#204 for just the inversible marking species/sex restrictions.

## Why / Balance
I want to do this on The Den too for the record. Markings are some of the most obnoxious and repetitive code in the entire game - consider this an act of mercy.

I did not go much further than reparenting the tattoos because I do not want to make you guys review 2000+ line changes in one PR. Lol. I would highly recommend using inheritance for markings, especially their species lists, from here on out, though

## Technical details
New fields added to MarkingPrototype: `invertSpeciesRestriction` and `invertSexRestriction` respectively. As the name suggests, this will invert the species and sex requirement lists of a marking - the marking will behave as if whitelisted for species that are not excluded.

Some new abstract marking prototypes have been added:
- `BaseTattoo` gives a marking tattoo coloring.
- `BaseEyes` give s a marking "inverted" eye coloring, and also assumes the marking applies to the Eyes layer of the humanoid.
- A handful of new species restriction bases. For example, `BaseSpeciesChestStandardOrganic` includes ALL species except the ones with non-standard chest sprites (Moth, Vox) and species that couldn't realistically have fleshy scars/tattoos (Diona, IPC). 

## How to test
In the character editor, validate the following:
- All species have the left/right eye markings, except `Arachnid, Diona, IPC, Moth, Vox`.
- All species have the "Nightling" Chest tattoo except `Moth, Vox, Diona, IPC`.
- Ditto for the doll arm joints, except Harpies are excluded too.
- Ditto for the doll leg joints, Harpies are excluded too.

## Media
Arachnids having doll joints, but not the left/right eye markings:
<img width="1542" height="506" alt="image" src="https://github.com/user-attachments/assets/81def7c2-92f1-4cb1-9f71-316b73feda94" />

Sheleg having doll joints and left/right eye markings:
<img width="1543" height="493" alt="image" src="https://github.com/user-attachments/assets/e78ff877-bf8d-455a-a09b-e2a47d0f5894" />

Harpies have Nightling tattoo but lack doll joints
<img width="1061" height="452" alt="image" src="https://github.com/user-attachments/assets/9ea475c2-6318-4f38-8cf5-16c984d6fc59" />
<img width="1551" height="442" alt="image" src="https://github.com/user-attachments/assets/aaf1ecaa-89c1-41f8-afe0-94c4b29e2cfe" />
<img width="1549" height="449" alt="image" src="https://github.com/user-attachments/assets/898da739-9d55-4766-b4eb-bd9f07d238a1" />


## Requirements
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes
Harpies lost a few arm/leg tattoo markings that did not fit their body sprites anyway.

**Changelog**
:cl:
- remove: Harpies lost a few arm/leg tattoo markings that did not fit their body sprites anyway.
