### PR TITLE
QM Dusters to Grand Gambling.

### DIFF
--- a/Resources/Prototypes/_AS/Entities/markers/Spawners/random/GRAND_LOTTERY.yml
+++ b/Resources/Prototypes/_AS/Entities/markers/Spawners/random/GRAND_LOTTERY.yml
@@ -117,6 +117,7 @@
     - GrenadeFoamDart
     - StorageFillAmmoBoxHonk35
     - StorageFillAmmoBoxHonk35SMG
+    - GoldenKnuckleduster
     chance: 1
     offset: 0.0
     rarePrototypes:

--- a/Resources/Prototypes/_AS/Entities/markers/Spawners/random/GRAND_LOTTERY.yml
+++ b/Resources/Prototypes/_AS/Entities/markers/Spawners/random/GRAND_LOTTERY.yml
@@ -117,7 +117,7 @@
     - GrenadeFoamDart
     - StorageFillAmmoBoxHonk35
     - StorageFillAmmoBoxHonk35SMG
-    - GoldenKnuckleduster
+    - ClothingHandsKnuckleDustersQM
     chance: 1
     offset: 0.0
     rarePrototypes:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
A method to get the QM dusters legitimately in a manner befitting its title.

## Why / Balance
Drip. And having another knuckleduster for flavour.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
-->
:cl: 
- add: QM Golden Knuckle Dusters to gamble crates. Rejoice.