### PR TITLE
Softcrit - Speak till you die

### DIFF
--- a/Content.Shared/Mobs/Systems/MobStateSystem.Subscribers.cs
+++ b/Content.Shared/Mobs/Systems/MobStateSystem.Subscribers.cs
@@ -34,14 +34,14 @@ public partial class MobStateSystem
         SubscribeLocalEvent<MobStateComponent, ThrowAttemptEvent>(CheckAct);
         SubscribeLocalEvent<MobStateComponent, SpeakAttemptEvent>(OnSpeakAttempt);
         SubscribeLocalEvent<MobStateComponent, IsEquippingAttemptEvent>(OnEquipAttempt);
-        SubscribeLocalEvent<MobStateComponent, EmoteAttemptEvent>(CheckAct);
+        SubscribeLocalEvent<MobStateComponent, EmoteAttemptEvent>(OnEmoteAttempt);
         SubscribeLocalEvent<MobStateComponent, IsUnequippingAttemptEvent>(OnUnequipAttempt);
         SubscribeLocalEvent<MobStateComponent, DropAttemptEvent>(CheckAct);
         SubscribeLocalEvent<MobStateComponent, PickupAttemptEvent>(CheckAct);
         SubscribeLocalEvent<MobStateComponent, StartPullAttemptEvent>(CheckAct);
         SubscribeLocalEvent<MobStateComponent, UpdateCanMoveEvent>(CheckAct);
         SubscribeLocalEvent<MobStateComponent, StandAttemptEvent>(CheckAct);
-        SubscribeLocalEvent<MobStateComponent, PointAttemptEvent>(CheckAct);
+        SubscribeLocalEvent<MobStateComponent, PointAttemptEvent>(OnPointAttempt);
         SubscribeLocalEvent<MobStateComponent, TryingToSleepEvent>(OnSleepAttempt);
         SubscribeLocalEvent<MobStateComponent, CombatModeShouldHandInteractEvent>(OnCombatModeShouldHandInteract);
         SubscribeLocalEvent<MobStateComponent, AttemptPacifiedAttackEvent>(OnAttemptPacifiedAttack);
@@ -141,12 +141,41 @@ public partial class MobStateSystem
 
     private void OnSpeakAttempt(EntityUid uid, MobStateComponent component, SpeakAttemptEvent args)
     {
-        if (MobState.Dead == component.CurrentState)
+        if (MobState.Dead == component.CurrentState) // Altered logic so criticals can still speak | Aurora Song
         {
             args.Cancel();
         }
 
 
+    }
+
+    // Don't strictly speaking need a separate function for either of these, but we can tailor specific behavior later if needed.
+    private void OnEmoteAttempt(EntityUid uid, MobStateComponent component, EmoteAttemptEvent args) // Aurora Song
+    {
+        if (MobState.Dead == component.CurrentState)
+        {
+            args.Cancel();
+        }
+    }
+
+    private void OnPointAttempt(EntityUid uid, MobStateComponent component, PointAttemptEvent args) // Aurora Song
+    {
+        if (MobState.Dead == component.CurrentState)
+        {
+            args.Cancel();
+        }
+    }
+
+    private void OnMoveAttempt(EntityUid target , MobStateComponent component, CancellableEntityEventArgs args) // Aurora Song - Currently unused
+    {
+        switch (component.CurrentState)
+        {
+            case MobState.Dead:
+            case MobState.Critical: //This prevents movement in critical state, for now
+                args.Cancel();
+                break;
+            // TODO: Allow movement, but slowed down, in critical state
+        }
     }
 
     private void CheckAct(EntityUid target, MobStateComponent component, CancellableEntityEventArgs args)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Small change to the logic of the mobstate system, meaning you now only fail to speak when you are dead.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Wanna beg for your life in crit? Maybe tell the medic where you are as they pass you again? Wouldn't it be cool if being crit wasn't just like being dead but somehow MORE restrictive?

## Technical details
<!-- Summary of code changes for easier review. -->
changed the logic of the OnSpeakAttempt function, swapping it to only cancel arguments if the mobstate is dead.

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

1. Load into release or test env
2. Stab self repeatedly until crit
3. Try to speak or emote
4. Ye gads! The dying thing spoke!

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Dying people can now speak!