### PR TITLE
AAC Tablet Width Fix

### DIFF
--- a/Content.Client/DeltaV/AACTablet/UI/AACWindow.xaml
+++ b/Content.Client/DeltaV/AACTablet/UI/AACWindow.xaml
@@ -2,8 +2,8 @@
     xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
     Title="{Loc 'aac-tablet-title'}"
     Resizable="True"
-    SetSize="540 300"
-    MinSize="540 300">
+    SetSize="590 300"
+    MinSize="590 300">
     <BoxContainer Orientation="Vertical">
         <BoxContainer Orientation="Horizontal" HorizontalExpand="True">
             <CheckBox Name="ShouldBuffer" Text="{Loc 'aac-tablet-combine'}"/>

--- a/Content.Client/DeltaV/AACTablet/UI/AACWindow.xaml.cs
+++ b/Content.Client/DeltaV/AACTablet/UI/AACWindow.xaml.cs
@@ -21,7 +21,7 @@ public sealed partial class AACWindow : FancyWindow
     public event Action? SubmitPressed;
 
     private const float SpaceWidth = 10f;
-    private const float ParentWidth = 540f;
+    private const float ParentWidth = 590f;
     private const int ColumnCount = 4;
 
     private const int ButtonWidth =


### PR DESCRIPTION


## About the PR
Changes the starting width of the AAC tablet window to be a bit wider to fit the new tabs

## Why / Balance
Not all the tabs fit on the window, leading some to be cut off.

## Technical details
Single line XAML change

## How to test
1. Pick up AAC tablet
1. Discover the lost tab

## Media

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).


## Breaking changes
N/A

**Changelog**
:cl:
- tweak: Changed the size of the AAC tablet menu to accomodate new tabs

