### PR TITLE
Softer Syndie Headlamp Colours, Buffed CE HeadlampE headlight

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -430,6 +430,8 @@
       - state: equipped-head-harpy
   - type: PointLight
     color: "#daffad"
+    radius: 8 # Aurora Song
+    energy: 3 #Aurora Song
   - type: PressureProtection
     highPressureMultiplier: 0.08
     lowPressureMultiplier: 1000
@@ -538,7 +540,7 @@
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/syndicate.rsi
   - type: PointLight
-    color: green
+    color: "#A9E2A9" # Aurora
     radius: 6 # Aurora
   - type: PressureProtection
     highPressureMultiplier: 0.08
@@ -567,7 +569,7 @@
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/syndiemedic.rsi
   - type: PointLight
-    color: green
+    color: "#A9E2A9" # Aurora
     radius: 6 # Aurora
   - type: PressureProtection
     highPressureMultiplier: 0.08
@@ -592,7 +594,7 @@
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/syndieelite.rsi
   - type: PointLight
-    color: red
+    color: "#FF9999" #Aurora
     radius: 6 # Aurora
   - type: PressureProtection
     highPressureMultiplier: 0.08
@@ -626,7 +628,7 @@
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/syndiecommander.rsi
   - type: PointLight
-    color: green
+    color: "#A9E2A9" # Aurora
     radius: 6 # Aurora
   - type: PressureProtection
     highPressureMultiplier: 0.08


### PR DESCRIPTION

## About the PR
Changed the colours of syndice hardsuit headlamps to be softer variants of their standard (red/green) to be softer on the eyes (and indirectly buff their effective range as the darker colours made it harder to see at the edge of the radius)

Also increases the headlight of the CE's hardsuit to be slightly longer than a luxury mining suit, as prior it had an unmodified radius of 3.

## Why / Balance
CE Headlight was godawful, and worse than just holding a flashlight in your hand.

Syndie suits (And their debranded variants) had colours that made it hard to see and distinguish some objects

## Technical details
YAML changes

## How to test
1. Get Syndie or CE hardsuit
2. Turn on headlight
3. Let There Be Light

## Media
<details>
  <summary>Unbranded Hardsuit</summary>
  
<img width="884" height="821" alt="image" src="https://github.com/user-attachments/assets/817056f1-f787-4cef-8c0f-fc4821c8ea04" />
(Before)
<img width="884" height="778" alt="image" src="https://github.com/user-attachments/assets/5148a104-7c53-418c-9fdf-191037c32f2f" />
(After)
</details>

<details>
  <summary>Unbranded Elite Hardsuit</summary>
  
<img width="962" height="790" alt="image" src="https://github.com/user-attachments/assets/df57a000-601f-4614-8b9b-e09cc4faa3a3" />
(Before)
<img width="837" height="759" alt="image" src="https://github.com/user-attachments/assets/dcf50450-0452-47e9-aa30-923bce807e96" />
(After)
</details>

<details>
  <summary>CE Hardsuit</summary>
  
<img width="966" height="824" alt="image" src="https://github.com/user-attachments/assets/db699af7-0313-46b9-b1d5-b67a3444cb72" />
(Before)
<img width="850" height="722" alt="image" src="https://github.com/user-attachments/assets/b6ab7cde-d235-4ed7-8e52-be5b260c2b57" />
(After)
</details>
## Requirements

- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).


## Breaking changes
N/A

**Changelog**
:cl:
- tweak: Softened colours of syndice hardsuit lights
- tweak: Increased brightness and radius of CE hardsuit light


