### PR TITLE
Exped Saviour System

### DIFF
--- a/Content.Server/Explosion/Components/TriggerOnMobstateChangeComponent.cs
+++ b/Content.Server/Explosion/Components/TriggerOnMobstateChangeComponent.cs
@@ -1,4 +1,5 @@
-﻿using Content.Shared.Mobs;
+﻿using System.Threading;
+using Content.Shared.Mobs;
 
 namespace Content.Server.Explosion.Components;
 
@@ -21,4 +22,21 @@ public sealed partial class TriggerOnMobstateChangeComponent : Component
     [ViewVariables]
     [DataField("preventSuicide")]
     public bool PreventSuicide = false;
+
+
+    /// <summary>
+    /// If false, this component will not trigger / is not allowed to work.
+    /// </summary>
+    [ViewVariables]
+    [DataField("enabled")]
+    public bool Enabled = true;
+
+
+    // the timer cancel token
+    [ViewVariables]
+    public CancellationTokenSource RattleCancelToken = new();
+
+    // The delay before the implant sends the message again
+    [DataField]
+    public TimeSpan RattleRefireDelay = TimeSpan.FromMinutes(20);
 }

--- a/Content.Server/Explosion/EntitySystems/TriggerSystem.Mobstate.cs
+++ b/Content.Server/Explosion/EntitySystems/TriggerSystem.Mobstate.cs
@@ -1,8 +1,11 @@
-﻿using Content.Server.Explosion.Components;
+﻿using System.Threading;
+using Content.Server.Explosion.Components;
 using Content.Shared.Explosion.Components;
 using Content.Shared.Implants;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Mobs;
+using Content.Shared.Mobs.Components;
+using Robust.Shared.Timing;
 
 namespace Content.Server.Explosion.EntitySystems;
 
@@ -15,11 +18,33 @@ public sealed partial class TriggerSystem
 
         SubscribeLocalEvent<TriggerOnMobstateChangeComponent, ImplantRelayEvent<SuicideEvent>>(OnSuicideRelay);
         SubscribeLocalEvent<TriggerOnMobstateChangeComponent, ImplantRelayEvent<MobStateChangedEvent>>(OnMobStateRelay);
+        SubscribeLocalEvent<TriggerOnMobstateChangeComponent, ImplantRelayEvent<ReTriggerRattleImplantEvent>>(OnFtlArriveRelay);
     }
 
     private void OnMobStateChanged(EntityUid uid, TriggerOnMobstateChangeComponent component, MobStateChangedEvent args)
     {
+        component.RattleCancelToken.Cancel();
+        component.RattleCancelToken = new CancellationTokenSource();
         if (!component.MobState.Contains(args.NewMobState))
+            return;
+
+        TryRunTrigger(
+            uid,
+            component,
+            args.Target,
+            args.NewMobState,
+            args.Origin);
+    }
+
+    private void TryRunTrigger(
+        EntityUid uid,
+        TriggerOnMobstateChangeComponent component,
+        EntityUid changedStateMobUid,
+        MobState coolState,
+        EntityUid? stateChangerUid = null,
+        bool retry = false)
+    {
+        if (!component.Enabled)
             return;
 
         //This chains Mobstate Changed triggers with OnUseTimerTrigger if they have it
@@ -28,14 +53,56 @@ public sealed partial class TriggerSystem
         {
             HandleTimerTrigger(
                 uid,
-                args.Origin,
+                stateChangerUid,
                 timerTrigger.Delay,
                 timerTrigger.BeepInterval,
                 timerTrigger.InitialBeepDelay,
                 timerTrigger.BeepSound);
         }
         else
-            Trigger(uid);
+        {
+            Dictionary<string, object> extraData = new()
+            {
+                { "isRetry", retry }
+            };
+            Trigger(uid, extras: extraData);
+        }
+
+        // then run it again
+        component.RattleCancelToken.Cancel();
+        component.RattleCancelToken = new CancellationTokenSource();
+        Robust.Shared.Timing.Timer.Spawn(component.RattleRefireDelay, () => CheckAndTryRefire(uid, component, changedStateMobUid), component.RattleCancelToken.Token);
+    }
+
+    /// <summary>
+    /// Check if the trigger can be retriggered and does so if possible
+    /// </summary>
+    private void CheckAndTryRefire(
+        EntityUid uid,
+        TriggerOnMobstateChangeComponent component,
+        EntityUid changedStateMobUid)
+    {
+        if (!Exists(uid)
+            || !Exists(changedStateMobUid))
+            return;
+        if (Deleted(uid)
+            || Deleted(changedStateMobUid))
+            return;
+        if (!HasComp<MobStateComponent>(changedStateMobUid))
+            return;
+        if (!component.Enabled)
+            return;
+        var stat = Comp<MobStateComponent>(changedStateMobUid).CurrentState;
+        if (component.MobState.Contains(stat))
+        {
+            TryRunTrigger(
+                uid,
+                component,
+                changedStateMobUid,
+                stat,
+                null,
+                true);
+        }
     }
 
     /// <summary>
@@ -61,6 +128,24 @@ public sealed partial class TriggerSystem
 
     private void OnMobStateRelay(EntityUid uid, TriggerOnMobstateChangeComponent component, ImplantRelayEvent<MobStateChangedEvent> args)
     {
-        OnMobStateChanged(uid, component, args.Event);
+        OnMobStateChanged(
+            uid,
+            component,
+            args.Event);
+    }
+
+    /// <summary>
+    /// When ftl arrives, try to retrigger their medical alerts
+    /// </summary>
+    private void OnFtlArriveRelay(EntityUid uid,
+        TriggerOnMobstateChangeComponent component,
+        ImplantRelayEvent<ReTriggerRattleImplantEvent> args)
+    {
+        TryRunTrigger(
+            uid,
+            component,
+            args.Event.Implanted,
+            args.Event.CurrentState,
+            null);
     }
 }

--- a/Content.Server/Explosion/EntitySystems/TriggerSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/TriggerSystem.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+using System.Threading;
 using Content.Server.Administration.Logs;
 using Content.Server.Body.Systems;
 using Content.Server.Explosion.Components;
@@ -35,6 +37,7 @@ using Content.Server.Station.Systems;
 using Content.Shared.Humanoid;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
+using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 using Content.Shared.Body.Components; // Frontier: Gib organs
 
@@ -47,11 +50,17 @@ namespace Content.Server.Explosion.EntitySystems
     {
         public EntityUid Triggered { get; }
         public EntityUid? User { get; }
+        public Dictionary<string, object> Extras { get; } = new();
 
         public TriggerEvent(EntityUid triggered, EntityUid? user = null)
         {
             Triggered = triggered;
             User = user;
+        }
+
+        public void AddExtra(string extra, object value)
+        {
+            Extras[extra] = value;
         }
     }
 
@@ -261,12 +270,16 @@ namespace Content.Server.Explosion.EntitySystems
 
             if (implanted.ImplantedEntity == null)
                 return;
+            if (!TryComp<MobStateComponent>(implanted.ImplantedEntity, out var mobstate)
+                || mobstate.CurrentState == MobState.Alive)
+                return;
+
 
             // Gets location of the implant
             var ownerXform = Transform(uid);
             var pos = ownerXform.MapPosition;
-            var x = (int) pos.X;
-            var y = (int) pos.Y;
+            var x = (int)pos.X;
+            var y = (int)pos.Y;
             var posText = $"({x}, {y})";
 
             // Frontier: Gets station location of the implant
@@ -281,20 +294,31 @@ namespace Content.Server.Explosion.EntitySystems
             if (TryComp<HumanoidAppearanceComponent>(implanted.ImplantedEntity, out var species))
                 speciesText = $" ({species!.Species})";
 
-            var critMessage = Loc.GetString(component.CritMessage, ("user", implanted.ImplantedEntity.Value), ("specie", speciesText), ("grid", stationText!), ("position", posText));
-            var deathMessage = Loc.GetString(component.DeathMessage, ("user", implanted.ImplantedEntity.Value), ("specie", speciesText), ("grid", stationText!), ("position", posText));
+            string localeKey;
 
-            if (!TryComp<MobStateComponent>(implanted.ImplantedEntity, out var mobstate))
-                return;
-
-            if (mobstate.CurrentState != MobState.Alive)
+            if (args.Extras.TryGetValue("isRetry", out var retryObj)
+                && retryObj is bool obj
+                && obj == true)
             {
-                // Sends a message to the radio channel specified by the implant
-                if (mobstate.CurrentState == MobState.Critical)
-                    _radioSystem.SendRadioMessage(uid, critMessage, _prototypeManager.Index<RadioChannelPrototype>(component.RadioChannel), uid);
-                if (mobstate.CurrentState == MobState.Dead)
-                    _radioSystem.SendRadioMessage(uid, deathMessage, _prototypeManager.Index<RadioChannelPrototype>(component.RadioChannel), uid);
+                localeKey = mobstate.CurrentState == MobState.Critical ? component.CritMessage : component.DeathMessage;
             }
+            else
+            {
+                localeKey = mobstate.CurrentState == MobState.Critical ? component.CritMessage : component.DeathMessage;
+            }
+
+            var message = Loc.GetString(
+                localeKey,
+                ("user", implanted.ImplantedEntity.Value),
+                ("specie", speciesText),
+                ("grid", stationText!),
+                ("position", posText));
+
+            _radioSystem.SendRadioMessage(
+                uid,
+                message,
+                _prototypeManager.Index<RadioChannelPrototype>(component.RadioChannel),
+                uid);
 
             args.Handled = true;
         }
@@ -354,7 +378,7 @@ namespace Content.Server.Explosion.EntitySystems
             ent.Comp.NextTrigger = _timing.CurTime + ent.Comp.Delay;
         }
 
-        public bool Trigger(EntityUid trigger, EntityUid? user = null)
+        public bool Trigger(EntityUid trigger, EntityUid? user = null, Dictionary<string, object>? extras = null)
         {
             var beforeTriggerEvent = new BeforeTriggerEvent(trigger, user);
             RaiseLocalEvent(trigger, ref beforeTriggerEvent);
@@ -362,6 +386,13 @@ namespace Content.Server.Explosion.EntitySystems
                 return false;
 
             var triggerEvent = new TriggerEvent(trigger, user);
+            if (extras != null)
+            {
+                foreach (var (key, value) in extras)
+                {
+                    triggerEvent.AddExtra(key, value);
+                }
+            }
             EntityManager.EventBus.RaiseLocalEvent(trigger, triggerEvent, true);
             return triggerEvent.Handled;
         }

--- a/Content.Server/Salvage/Expeditions/SalvageExpeditionComponent.cs
+++ b/Content.Server/Salvage/Expeditions/SalvageExpeditionComponent.cs
@@ -61,4 +61,10 @@ public sealed partial class SalvageExpeditionComponent : SharedSalvageExpedition
     // [DataField]
     // public ResolvedSoundSpecifier SelectedSong;
     // End Frontier: moved to Shared
+
+    /// <summary>
+    /// next time to check for autoabort
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite), DataField]
+    public TimeSpan NextAutoAbortCheck = TimeSpan.Zero;
 }

--- a/Content.Server/Salvage/SalvageSystem.Runner.cs
+++ b/Content.Server/Salvage/SalvageSystem.Runner.cs
@@ -27,7 +27,15 @@ using Robust.Shared.Map; // Frontier
 using Content.Server.GameTicking; // Frontier
 using Content.Server._NF.Salvage.Expeditions.Structure; // Frontier
 using Content.Server._NF.Salvage.Expeditions;
-using Content.Shared.Salvage; // Frontier
+using Content.Server.Buckle.Systems;
+using Content.Shared.Buckle.Components;
+using Content.Shared.Mind.Components;
+using Content.Shared.Salvage;
+using Content.Shared.Warps;
+using Robust.Server.Player;
+using Robust.Shared.Audio;
+using Robust.Shared.Audio.Systems;
+using Robust.Shared.Enums; // Frontier
 
 namespace Content.Server.Salvage;
 
@@ -40,6 +48,7 @@ public sealed partial class SalvageSystem
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly GameTicker _gameTicker = default!; // Frontier
     [Dependency] private readonly DamageableSystem _damageable = default!;
+    [Dependency] private readonly IPlayerManager _players = default!;
 
     private void InitializeRunner()
     {
@@ -208,6 +217,8 @@ public sealed partial class SalvageSystem
             var remaining = comp.EndTime - _timing.CurTime;
             var audioLength = _audio.GetAudioLength(comp.SelectedSong);
 
+            AbortIfWiped(uid, comp); // Frontier
+
             if (comp.Stage < ExpeditionStage.FinalCountdown && remaining < TimeSpan.FromSeconds(45))
             {
                 comp.Stage = ExpeditionStage.FinalCountdown;
@@ -296,7 +307,13 @@ public sealed partial class SalvageSystem
                                 dropLocation = _random.NextVector2(minRange, maxRange);
                             }
 
-                            _shuttle.FTLToCoordinates(shuttleUid, shuttle, new EntityCoordinates(mapUid.Value, dropLocation), 0f, ftlTime, TravelTime);
+                            _shuttle.FTLToCoordinates(
+                                shuttleUid,
+                                shuttle,
+                                new EntityCoordinates(mapUid.Value, dropLocation),
+                                0f,
+                                ftlTime,
+                                TravelTime);
                             // End Frontier:  try to find a potential destination for ship that doesn't collide with other grids.
                             //_shuttle.FTLToDock(shuttleUid, shuttle, member, ftlTime); // Frontier: use above instead
                         }
@@ -325,6 +342,10 @@ public sealed partial class SalvageSystem
                             {
                                 // If they aren't on the expedition map, don't want em
                                 if (mobXform.MapUid != uid)
+                                    continue;
+
+                                //if they are on the shuttle, don't bother.
+                                if (mobXform.GridUid == shuttleUid)
                                     continue;
 
                                 // Not player controlled at any point
@@ -438,6 +459,69 @@ public sealed partial class SalvageSystem
             }
         }
         // End Frontier: mission-specific logic
+    }
+
+    /// <summary>
+    /// Checks if everyone on the map worth caring about is dead, and aborts the expedition if so.
+    /// Honestly, as long as one person is not in crit and not SSD, we consider the expedition salvageable.
+    /// </summary>
+    private void AbortIfWiped(EntityUid mapUid, SalvageExpeditionComponent component)
+    {
+        // give it a 30 second grade after first check to avoid instant aborts
+        if (component.NextAutoAbortCheck == TimeSpan.Zero)
+        {
+            component.NextAutoAbortCheck = _timing.CurTime + TimeSpan.FromSeconds(30);
+            return;
+        }
+        // only check frequently in case of some method of revival and/or performance methods
+        if (_timing.CurTime < component.NextAutoAbortCheck)
+            return;
+        component.NextAutoAbortCheck = _timing.CurTime + TimeSpan.FromSeconds(15);
+
+        var query =
+            EntityQueryEnumerator<
+                HumanoidAppearanceComponent,
+                MindContainerComponent,
+                MobStateComponent,
+                TransformComponent>();
+        // prevent abort if:
+        // - anyone is alive AND connected
+        while (query.MoveNext(
+                   out var uid,
+                   out _,
+                   out var mindC,
+                   out var mobState,
+                   out var xform))
+        {
+            if (xform.MapUid != mapUid)
+                continue;
+            // unidentified humans (loot) dont count
+            if (!mindC.HasMind)
+                continue;
+            // if anyone is alive and not in crit, we are good
+            if (_mobState.IsAlive(uid, mobState))
+            {
+                // okay weve got something alive, is their session?
+                _players.TryGetSessionByEntity(uid, out var session);
+                // if no session, check if they are SSD
+                if (session == null)
+                    continue;
+                if (session.Status == SessionStatus.Disconnected)
+                    continue;
+                return; // alive and connected player found, expedition is salvageable
+            }
+        }
+        // everyone is dead or ssd, abort the expedition
+        const int departTime = 20;
+        Announce(mapUid, Loc.GetString("salvage-expedition-abort-wipe", ("departTime", departTime)));
+        component.NextAutoAbortCheck = TimeSpan.FromDays(1); // prevent further checks
+        var newEndTime = _timing.CurTime + TimeSpan.FromSeconds(departTime);
+
+        if (component.EndTime <= newEndTime)
+            return;
+
+        component.Stage = ExpeditionStage.FinalCountdown;
+        component.EndTime = newEndTime;
     }
 }
 

--- a/Content.Server/Salvage/SalvageSystem.Runner.cs
+++ b/Content.Server/Salvage/SalvageSystem.Runner.cs
@@ -1,4 +1,5 @@
 using System.Numerics;
+using Content.Server._NF.Salvage; //AS
 using Content.Server.Salvage.Expeditions;
 using Content.Server.Shuttles.Components;
 using Content.Server.Shuttles.Events;
@@ -7,10 +8,20 @@ using Content.Shared.Chat;
 using Content.Shared.Humanoid;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
+using Content.Shared.EntityEffects;
+using Content.Shared.NPC; //AS
+using Content.Shared.Damage; //AS
+using Content.Shared.Damage.Prototypes; //AS
+using Content.Shared.NPC.Components; //AS
+using Content.Shared.NPC.Systems; //AS
 using Content.Shared.Salvage.Expeditions;
 using Content.Shared.Shuttles.Components;
 using Content.Shared.Localizations;
+using Content.Shared.Mind.Components; // AS
+using Content.Shared.Mobs.Components; // AS
+using Content.Shared.Warps; // AS
 using Robust.Shared.Map.Components;
+using Robust.Server.GameObjects;
 using Robust.Shared.Player;
 using Robust.Shared.Map; // Frontier
 using Content.Server.GameTicking; // Frontier
@@ -28,6 +39,7 @@ public sealed partial class SalvageSystem
 
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly GameTicker _gameTicker = default!; // Frontier
+    [Dependency] private readonly DamageableSystem _damageable = default!;
 
     private void InitializeRunner()
     {
@@ -294,6 +306,70 @@ public sealed partial class SalvageSystem
                 }
             }
 
+            if (remaining < TimeSpan.FromSeconds(1)) // AS: Get players and non-hostile ghost roles left on the expedition and yeet them onto the shuttle before we delete the map
+            {
+                var shuttleQuery = AllEntityQuery<ShuttleComponent, TransformComponent>();
+
+                if (TryComp<StationDataComponent>(comp.Station, out var data))
+                {
+                    foreach (var member in data.Grids)
+                    {
+                        while (shuttleQuery.MoveNext(out var shuttleUid, out var shuttle, out var shuttleXform))
+                        {
+                            if (shuttleXform.MapUid != uid)
+                                continue;
+
+                            // Get everyone we want to recover that is on the map and not on the shuttle
+                            var playerQuery = EntityQueryEnumerator<MindContainerComponent, MobStateComponent, TransformComponent>();
+                            while (playerQuery.MoveNext(out var quid, out var mindContainer, out var _, out var mobXform))
+                            {
+                                // If they aren't on the expedition map, don't want em
+                                if (mobXform.MapUid != uid)
+                                    continue;
+
+                                // Not player controlled at any point
+                                if (!mindContainer.HasMind)
+                                    continue;
+
+                                // NPC, definitely not a person
+                                if (HasComp<ActiveNPCComponent>(quid) || HasComp<NFSalvageMobRestrictionsComponent>(quid))
+                                    continue;
+
+                                // Hostile ghost role, continue
+                                if (TryComp(quid, out NpcFactionMemberComponent? npcFaction))
+                                {
+                                    var hostileFactions = npcFaction.HostileFactions;
+                                    if (hostileFactions.Contains("NanoTrasen")) // TODO: move away from hardcoded faction
+                                        continue;
+                                }
+                                // If we got this far, we want to try and find a warp point on their ship and warp them to it
+                                var warpQuery = EntityQueryEnumerator<WarpPointComponent, TransformComponent>();
+                                while (warpQuery.MoveNext(out var wuid, out var _, out var warpXform))
+                                {
+                                    if (Transform(wuid).GridUid != shuttleUid)
+                                        continue;
+                                    // first we ensure they are dead
+                                    if (_mobState.IsAlive(quid))
+                                    {
+                                        // Apply a large bricks worth of damage
+                                        var damageAmount = new DamageSpecifier()
+                                        {
+                                            DamageDict = { ["Slash"] = 75, ["Blunt"] = 75, ["Heat"] = 75 }  // If you are still alive after this you deserve it
+                                        };
+                                        _damageable.TryChangeDamage(quid, damageAmount, true);
+                                    }
+                                    // now teleport them to the first one we found
+                                    _transform.SetCoordinates(quid, mobXform, warpXform.Coordinates);
+                                    _transform.AttachToGridOrMap(quid, mobXform);
+                                    Spawn("EffectFlashBluespaceQuiet", mobXform.Coordinates);
+                                    break;
+                                }
+                            } // End AS
+                        }
+                    }
+                }
+            }
+
             if (remaining < TimeSpan.Zero)
             {
                 QueueDel(uid);
@@ -364,3 +440,4 @@ public sealed partial class SalvageSystem
         // End Frontier: mission-specific logic
     }
 }
+

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
@@ -10,7 +10,10 @@ using Content.Shared.Body.Components;
 using Content.Shared.CCVar;
 using Content.Shared.Database;
 using Content.Shared.Ghost;
+using Content.Shared.Implants;
+using Content.Shared.Implants.Components;
 using Content.Shared.Maps;
+using Content.Shared.Mobs.Components;
 using Content.Shared.Parallax;
 using Content.Shared.Shuttles.Components;
 using Content.Shared.Shuttles.Systems;
@@ -955,6 +958,23 @@ public sealed partial class ShuttleSystem
             {
                 Enable(uid, component: body, shuttle: entity.Comp2);
             }
+        }
+
+        // COYOTE: when the shuttle arrives, go through all the mobs on the grid
+        // and attempt to set off their deathrattle implants
+        var shuttleGridId = xform.GridUid;
+        var implantedQuery = EntityQueryEnumerator<ImplantedComponent, MobStateComponent, TransformComponent>();
+        while (implantedQuery.MoveNext(
+           out var mobUid,
+           out var implanted,
+           out var mobState,
+           out var mobXform))
+        {
+            if (mobXform.GridUid != shuttleGridId)
+                continue;
+
+            var deathrattleEvent = new ReTriggerRattleImplantEvent(mobUid, mobState.CurrentState);
+            RaiseLocalEvent(mobUid, deathrattleEvent);
         }
     }
 

--- a/Content.Shared/Implants/Components/RattleComponent.cs
+++ b/Content.Shared/Implants/Components/RattleComponent.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using Content.Shared.Radio;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;

--- a/Content.Shared/Implants/SharedSubdermalImplantSystem.cs
+++ b/Content.Shared/Implants/SharedSubdermalImplantSystem.cs
@@ -32,6 +32,7 @@ public abstract class SharedSubdermalImplantSystem : EntitySystem
         SubscribeLocalEvent<ImplantedComponent, MobStateChangedEvent>(RelayToImplantEvent);
         SubscribeLocalEvent<ImplantedComponent, AfterInteractUsingEvent>(RelayToImplantEvent);
         SubscribeLocalEvent<ImplantedComponent, SuicideEvent>(RelayToImplantEvent);
+        SubscribeLocalEvent<ImplantedComponent, ReTriggerRattleImplantEvent>(RelayToImplantEvent);
     }
 
     private void OnInsert(EntityUid uid, SubdermalImplantComponent component, EntGotInsertedIntoContainerMessage args)
@@ -218,4 +219,16 @@ public readonly struct ImplantImplantedEvent
         Implant = implant;
         Implanted = implanted;
     }
+}
+
+/// <summary>
+/// Event used to re-trigger implant events, if needed.
+/// Raised on the implanted entity.
+/// </summary>
+public sealed class ReTriggerRattleImplantEvent(
+    EntityUid implanted,
+    MobState currentState) : EventArgs
+{
+    public readonly EntityUid Implanted = implanted;
+    public readonly MobState CurrentState = currentState;
 }

--- a/Resources/Locale/en-US/_NF/procedural/expeditions.ftl
+++ b/Resources/Locale/en-US/_NF/procedural/expeditions.ftl
@@ -11,6 +11,8 @@ salvage-expedition-announcement-elimination = { $count ->
 salvage-expedition-announcement-destruction-entity-fallback = structure
 salvage-expedition-announcement-elimination-entity-fallback = target
 
+salvage-expedition-abort-wipe = Critical mission failure detected, engaging evacuation and recovery protocols. Shuttle will depart in {$departTime} seconds.
+
 salvage-expedition-shuttle-not-found = Cannot locate shuttle.
 salvage-expedition-not-everyone-aboard = Not all crew aboard! {CAPITALIZE(THE($target))} is still out there!
 salvage-expedition-failed = Expedition is failed.


### PR DESCRIPTION
## About the PR
Adds a system to recover people stranded on expeditions when the shuttle leaves

Also ports auto aborting expeds from [Coyote Station](https://github.com/ARF-SS13/coyote-frontier/pull/470) and the retriggering of medical alarms after the FTL finishes.

## Why / Balance
Compared to just sitting around and doing UIVs or Vroids, the risk is much higher for the same reward, alongside our low server pop making the process of gathering crew for expeds relatively rare. This system makes makes failing an expedition no longer grounds for round removal.

## Technical details
Minour C# changes

## How to test
1. Go to an exped
2. Die (optional)
3. Be left behind
4. Get warped back to your shuttle after being hit with a brick to ensure your death.

## Media
N/A

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes
N/A

**Changelog**
:cl:
- tweak: Being left behind on an expedition is no longer round removing.
- tweak: Expeditions auto abort after some time if all players are dead.
- add: Medical alarms are retriggered after FTL ends

