### PR TITLE
Allow seperate reward values for SCU and EC

### DIFF
--- a/Content.Client/_AS/Pirate/BUI/PiratePalletConsoleBoundUserInterface.cs
+++ b/Content.Client/_AS/Pirate/BUI/PiratePalletConsoleBoundUserInterface.cs
@@ -39,12 +39,12 @@ public sealed class PiratePalletConsoleBoundUserInterface : BoundUserInterface
 
     private void OnAppraisal()
     {
-        SendMessage(new PiratePalletAppraiseMessage());
+        SendMessage(new ContrabandPalletAppraiseMessage()); // AS: Fix pirate console
     }
 
     private void OnSell()
     {
-        SendMessage(new PiratePalletSellMessage());
+        SendMessage(new ContrabandPalletSellMessage()); // AS: Fix pirate console
     }
 
     protected override void UpdateState(BoundUserInterfaceState state)

--- a/Content.Client/_NF/Contraband/BUI/ContrabandPalletConsoleBoundUserInterface.cs
+++ b/Content.Client/_NF/Contraband/BUI/ContrabandPalletConsoleBoundUserInterface.cs
@@ -66,7 +66,7 @@ public sealed class ContrabandPalletConsoleBoundUserInterface : BoundUserInterfa
             return;
 
         _menu?.SetEnabled(palletState.Enabled);
-        _menu?.SetAppraisal(palletState.Appraisal);
+        _menu?.SetAppraisal(palletState.Appraisal, palletState.AltAppraisal); // AS: Allow alt reward currencies
         _menu?.SetCount(palletState.Count);
         _menu?.SetUnregistered(palletState.Unregistered);
     }

--- a/Content.Client/_NF/Contraband/UI/ContrabandPalletMenu.xaml.cs
+++ b/Content.Client/_NF/Contraband/UI/ContrabandPalletMenu.xaml.cs
@@ -52,12 +52,11 @@ public sealed partial class ContrabandPalletMenu : FancyWindow
     {
         // TODO: switch currency function by currency in component
         AppraisalLabel.Text = Loc.GetString($"{_locPrefix}contraband-console-menu-points-amount", ("amount", BankSystemExtensions.ToIndependentString(amount)));
-        if(_locPrefix == "") // AS: Allow alt reward currencies | Hacky as hell but its the best I could come up with.
+        if (_locPrefix == "") // AS: Allow alt reward currencies | Hacky as hell but its the best I could come up with.
         {
             AppraisalLabel.Text += " & ";
             AppraisalLabel.Text += Loc.GetString("contraband-console-menu-points-amount-alt", ("altAmount", BankSystemExtensions.ToIndependentString(altAmount)));
         }
-        
     }
 
     public void SetCount(int count)

--- a/Content.Client/_NF/Contraband/UI/ContrabandPalletMenu.xaml.cs
+++ b/Content.Client/_NF/Contraband/UI/ContrabandPalletMenu.xaml.cs
@@ -48,10 +48,16 @@ public sealed partial class ContrabandPalletMenu : FancyWindow
         }
     }
 
-    public void SetAppraisal(int amount)
+    public void SetAppraisal(int amount, int altAmount) // AS: Allow alt reward currencies
     {
         // TODO: switch currency function by currency in component
         AppraisalLabel.Text = Loc.GetString($"{_locPrefix}contraband-console-menu-points-amount", ("amount", BankSystemExtensions.ToIndependentString(amount)));
+        if(_locPrefix == "") // AS: Allow alt reward currencies | Hacky as hell but its the best I could come up with.
+        {
+            AppraisalLabel.Text += " & ";
+            AppraisalLabel.Text += Loc.GetString("contraband-console-menu-points-amount-alt", ("altAmount", BankSystemExtensions.ToIndependentString(altAmount)));
+        }
+        
     }
 
     public void SetCount(int count)

--- a/Content.Server/_NF/Contraband/Systems/ContrabandTurnInSystem.cs
+++ b/Content.Server/_NF/Contraband/Systems/ContrabandTurnInSystem.cs
@@ -196,12 +196,12 @@ public sealed partial class ContrabandTurnInSystem : SharedContrabandTurnInSyste
                     && (turnInValues.ContainsKey(console.Comp.RewardType) || turnInValues.ContainsKey(console.Comp.RewardTypeAlternate))) // AS: Allow alt reward currencies
                 {
                     toSell.Add(ent);
-                    if ( turnInValues.ContainsKey(console.Comp.RewardTypeAlternate)) // Begin AS: Allow alt reward currencies
+                    if (turnInValues.ContainsKey(console.Comp.RewardTypeAlternate)) // Begin AS: Allow alt reward currencies
                     {
                         var altValue = comp.TurnInValues[console.Comp.RewardTypeAlternate];
                         altAmount += altValue;
                     }
-                    if ( turnInValues.ContainsKey(console.Comp.RewardType))
+                    if (turnInValues.ContainsKey(console.Comp.RewardType))
                     {
                         var value = comp.TurnInValues[console.Comp.RewardType];
                         amount += value;
@@ -250,7 +250,7 @@ public sealed partial class ContrabandTurnInSystem : SharedContrabandTurnInSyste
 
         if (!CheckLicense(component, player)) // Aurora: add check for chl
         {
-            PlayDenyEffect((uid,component));
+            PlayDenyEffect((uid, component));
             return;
         }
 
@@ -263,14 +263,28 @@ public sealed partial class ContrabandTurnInSystem : SharedContrabandTurnInSyste
 
         SellPallets(gridUid, (uid, component), null, out var reward, out var altReward); // AS: Allow alt reward currencies
 
-        var rewardPrototype = _protoMan.Index<StackPrototype>(component.RewardType); // AS: Allow alt reward currencies
-        var stackUid = _stack.Spawn(reward, rewardPrototype, _scuOutput.ToCoordinates()); // AS: Allow alt reward currencies
-        _transform.SetLocalRotation(stackUid, Angle.Zero); // Orient these to grid north instead of map north
+        var outputQuery = EntityQueryEnumerator<ScuOutputComponent, TransformComponent>(); // Begin AS: Makes pirate contraband selling usable
+        var output = uid.ToCoordinates();
+        while (outputQuery.MoveNext(out var _, out var xform))
+        {
+            if (xform.GridUid == gridUid)
+                output = _scuOutput.ToCoordinates();
+        }
 
-        var altRewardPrototype = _protoMan.Index<StackPrototype>(component.RewardTypeAlternate); // AS: Allow alt reward currencies
-        stackUid = _stack.Spawn(altReward, altRewardPrototype, args.Actor.ToCoordinates()); // AS: Allow alt reward currencies
-        if (!_hands.TryPickupAnyHand(args.Actor, stackUid))
-            _transform.SetLocalRotation(stackUid, Angle.Zero); // Orient these to grid north instead of map north
+        if (component.RewardType != "")
+        {
+            var rewardPrototype = _protoMan.Index<StackPrototype>(component.RewardType); // AS: Allow alt reward currencies
+            var stackUid = _stack.Spawn(reward, rewardPrototype, output); // AS: Allow alt reward currencies
+            _transform.SetLocalRotation(stackUid, Angle.Zero);
+        }
+
+        if (component.RewardTypeAlternate != "")
+        {
+            var altRewardPrototype = _protoMan.Index<StackPrototype>(component.RewardTypeAlternate); // AS: Allow alt reward currencies
+            var altStackUid = _stack.Spawn(altReward, altRewardPrototype, args.Actor.ToCoordinates()); // AS: Allow alt reward currencies
+            if (!_hands.TryPickupAnyHand(args.Actor, altStackUid))
+                _transform.SetLocalRotation(altStackUid, Angle.Zero); // Orient these to grid north instead of map north
+        } // End AS
         UpdatePalletConsoleInterface(uid, component);
     }
 
@@ -289,7 +303,7 @@ public sealed partial class ContrabandTurnInSystem : SharedContrabandTurnInSyste
                 new ContrabandPalletConsoleInterfaceState(0, 0, 0, 0, false)); // AS: Allow alt reward currencies
             return;
         }
-        GetPalletGoods(gridUid, ent, out _, out _ , out _, out var toRegister); // AS: Allow alt reward currencies
+        GetPalletGoods(gridUid, ent, out _, out _, out _, out var toRegister); // AS: Allow alt reward currencies
 
         // Award SCUs
         var stackPrototype = _protoMan.Index<StackPrototype>(ent.Comp.RewardType);

--- a/Content.Server/_NF/Contraband/Systems/ContrabandTurnInSystem.cs
+++ b/Content.Server/_NF/Contraband/Systems/ContrabandTurnInSystem.cs
@@ -77,16 +77,16 @@ public sealed partial class ContrabandTurnInSystem : SharedContrabandTurnInSyste
         if (Transform(uid).GridUid is not EntityUid gridUid)
         {
             _uiSystem.SetUiState(uid, ContrabandPalletConsoleUiKey.Contraband,
-                new ContrabandPalletConsoleInterfaceState(0, 0, 0, false));
+                new ContrabandPalletConsoleInterfaceState(0, 0, 0, 0, false)); // AS: Allow alt reward currencies
             return;
         }
 
-        GetPalletGoods(gridUid, (uid, comp), out var toSell, out var amount, out var unregistered);
+        GetPalletGoods(gridUid, (uid, comp), out var toSell, out var amount, out var altAmount, out var unregistered); // AS: Allow alt reward currencies
 
         var totalCount = toSell;
         toSell.UnionWith(unregistered);
         _uiSystem.SetUiState(uid, ContrabandPalletConsoleUiKey.Contraband,
-            new ContrabandPalletConsoleInterfaceState((int) amount, totalCount.Count, unregistered.Count, true));
+            new ContrabandPalletConsoleInterfaceState((int) amount, (int) altAmount, totalCount.Count, unregistered.Count, true)); // AS: Allow alt reward currencies
     }
 
     private void OnPalletUIOpen(EntityUid uid, ContrabandPalletConsoleComponent component, BoundUIOpenedEvent args)
@@ -146,12 +146,12 @@ public sealed partial class ContrabandTurnInSystem : SharedContrabandTurnInSyste
         return pads;
     }
 
-    private void SellPallets(EntityUid gridUid, Entity<ContrabandPalletConsoleComponent> component, EntityUid? station, out int amount)
+    private void SellPallets(EntityUid gridUid, Entity<ContrabandPalletConsoleComponent> component, EntityUid? station, out int amount, out int altAmount) // AS: Allow alt reward currencies
     {
         station ??= _station.GetOwningStation(gridUid);
-        GetPalletGoods(gridUid, component, out var toSell, out amount , out _);
+        GetPalletGoods(gridUid, component, out var toSell, out amount, out altAmount, out _); // AS: Allow alt reward currencies
 
-        Log.Debug($"{component.Comp.Faction} sold {toSell.Count} contraband items for {amount}");
+        Log.Debug($"{component.Comp.Faction} sold {toSell.Count} contraband items for {amount} primary currency and {altAmount} alternate currency");
 
         if (station != null)
         {
@@ -165,9 +165,10 @@ public sealed partial class ContrabandTurnInSystem : SharedContrabandTurnInSyste
         }
     }
 
-    private void GetPalletGoods(EntityUid gridUid, Entity<ContrabandPalletConsoleComponent> console, out HashSet<EntityUid> toSell, out int amount, out HashSet<EntityUid> unregistered)
+    private void GetPalletGoods(EntityUid gridUid, Entity<ContrabandPalletConsoleComponent> console, out HashSet<EntityUid> toSell, out int amount, out int altAmount, out HashSet<EntityUid> unregistered) // AS: Allow alt reward currencies
     {
         amount = 0;
+        altAmount = 0;
         toSell = new HashSet<EntityUid>();
         unregistered = new HashSet<EntityUid>(); // Aurora
 
@@ -192,11 +193,19 @@ public sealed partial class ContrabandTurnInSystem : SharedContrabandTurnInSyste
                 if (TryComp<ContrabandComponent>(ent, out var comp)
                     && !toSell.Contains(ent)
                     && comp.TurnInValues is { } turnInValues
-                    && turnInValues.ContainsKey(console.Comp.RewardType))
+                    && (turnInValues.ContainsKey(console.Comp.RewardType) || turnInValues.ContainsKey(console.Comp.RewardTypeAlternate))) // AS: Allow alt reward currencies
                 {
                     toSell.Add(ent);
-                    var value = comp.TurnInValues[console.Comp.RewardType];
-                    amount += value;
+                    if ( turnInValues.ContainsKey(console.Comp.RewardTypeAlternate)) // Begin AS: Allow alt reward currencies
+                    {
+                        var altValue = comp.TurnInValues[console.Comp.RewardTypeAlternate];
+                        altAmount += altValue;
+                    }
+                    if ( turnInValues.ContainsKey(console.Comp.RewardType))
+                    {
+                        var value = comp.TurnInValues[console.Comp.RewardType];
+                        amount += value;
+                    } // End AS
                 }
 
                 // Aurora
@@ -248,18 +257,18 @@ public sealed partial class ContrabandTurnInSystem : SharedContrabandTurnInSyste
         if (Transform(uid).GridUid is not EntityUid gridUid)
         {
             _uiSystem.SetUiState(uid, ContrabandPalletConsoleUiKey.Contraband,
-                new ContrabandPalletConsoleInterfaceState(0, 0, 0, false));
+                new ContrabandPalletConsoleInterfaceState(0, 0, 0, 0, false)); // AS: Allow alt reward currencies
             return;
         }
 
-        SellPallets(gridUid, (uid, component), null, out var price);
+        SellPallets(gridUid, (uid, component), null, out var reward, out var altReward); // AS: Allow alt reward currencies
 
-        var stackPrototype = _protoMan.Index<StackPrototype>(component.RewardType);
-        var stackUid = _stack.Spawn(price, stackPrototype, _scuOutput.ToCoordinates()); // Aurora spawn on scu output
+        var rewardPrototype = _protoMan.Index<StackPrototype>(component.RewardType); // AS: Allow alt reward currencies
+        var stackUid = _stack.Spawn(reward, rewardPrototype, _scuOutput.ToCoordinates()); // AS: Allow alt reward currencies
         _transform.SetLocalRotation(stackUid, Angle.Zero); // Orient these to grid north instead of map north
 
-        var rewardPrototype = _protoMan.Index<StackPrototype>(component.RewardCashPrototype); // Aurora: need EC prototype defined in scope
-        stackUid = _stack.Spawn(price, rewardPrototype, args.Actor.ToCoordinates()); // Aurora: spawn "cash" (now EC)
+        var altRewardPrototype = _protoMan.Index<StackPrototype>(component.RewardTypeAlternate); // AS: Allow alt reward currencies
+        stackUid = _stack.Spawn(altReward, altRewardPrototype, args.Actor.ToCoordinates()); // AS: Allow alt reward currencies
         if (!_hands.TryPickupAnyHand(args.Actor, stackUid))
             _transform.SetLocalRotation(stackUid, Angle.Zero); // Orient these to grid north instead of map north
         UpdatePalletConsoleInterface(uid, component);
@@ -277,10 +286,10 @@ public sealed partial class ContrabandTurnInSystem : SharedContrabandTurnInSyste
         if (Transform(ent).GridUid is not EntityUid gridUid)
         {
             _uiSystem.SetUiState(ent.Owner, ContrabandPalletConsoleUiKey.Contraband,
-                new ContrabandPalletConsoleInterfaceState(0, 0, 0, false));
+                new ContrabandPalletConsoleInterfaceState(0, 0, 0, 0, false)); // AS: Allow alt reward currencies
             return;
         }
-        GetPalletGoods(gridUid, ent, out _, out _ , out var toRegister);
+        GetPalletGoods(gridUid, ent, out _, out _ , out _, out var toRegister); // AS: Allow alt reward currencies
 
         // Award SCUs
         var stackPrototype = _protoMan.Index<StackPrototype>(ent.Comp.RewardType);

--- a/Content.Server/_NF/Contraband/Systems/ContrabandTurnInSystem.cs
+++ b/Content.Server/_NF/Contraband/Systems/ContrabandTurnInSystem.cs
@@ -193,15 +193,15 @@ public sealed partial class ContrabandTurnInSystem : SharedContrabandTurnInSyste
                 if (TryComp<ContrabandComponent>(ent, out var comp)
                     && !toSell.Contains(ent)
                     && comp.TurnInValues is { } turnInValues
-                    && (turnInValues.ContainsKey(console.Comp.RewardType) || turnInValues.ContainsKey(console.Comp.RewardTypeAlternate))) // AS: Allow alt reward currencies
+                    && (console.Comp.RewardType != null && turnInValues.ContainsKey(console.Comp.RewardType) || console.Comp.RewardTypeAlternate != null && turnInValues.ContainsKey(console.Comp.RewardTypeAlternate))) // AS: Allow alt reward currencies
                 {
                     toSell.Add(ent);
-                    if (turnInValues.ContainsKey(console.Comp.RewardTypeAlternate)) // Begin AS: Allow alt reward currencies
+                    if (console.Comp.RewardTypeAlternate != null && turnInValues.ContainsKey(console.Comp.RewardTypeAlternate)) // Begin AS: Allow alt reward currencies
                     {
                         var altValue = comp.TurnInValues[console.Comp.RewardTypeAlternate];
                         altAmount += altValue;
                     }
-                    if (turnInValues.ContainsKey(console.Comp.RewardType))
+                    if (console.Comp.RewardType != null && turnInValues.ContainsKey(console.Comp.RewardType))
                     {
                         var value = comp.TurnInValues[console.Comp.RewardType];
                         amount += value;
@@ -265,20 +265,33 @@ public sealed partial class ContrabandTurnInSystem : SharedContrabandTurnInSyste
 
         var outputQuery = EntityQueryEnumerator<ScuOutputComponent, TransformComponent>(); // Begin AS: Makes pirate contraband selling usable
         var output = uid.ToCoordinates();
+        var outputSent = false;
         while (outputQuery.MoveNext(out var _, out var xform))
         {
             if (xform.GridUid == gridUid)
+            {
                 output = _scuOutput.ToCoordinates();
+                outputSent = true;
+            }
         }
 
-        if (component.RewardType != "")
+        if (component.RewardType != null) 
         {
             var rewardPrototype = _protoMan.Index<StackPrototype>(component.RewardType); // AS: Allow alt reward currencies
             var stackUid = _stack.Spawn(reward, rewardPrototype, output); // AS: Allow alt reward currencies
-            _transform.SetLocalRotation(stackUid, Angle.Zero);
+            if (outputSent == false)
+            {
+                if (!_hands.TryPickupAnyHand(args.Actor, stackUid)) // If there wasn't a a ScuOutputComponent to send these too, try to pick them up
+                    _transform.SetLocalRotation(stackUid, Angle.Zero);
+            }
+            else
+            {
+                _transform.SetLocalRotation(stackUid, Angle.Zero); // Orient these to grid north instead of map north
+            }
+
         }
 
-        if (component.RewardTypeAlternate != "")
+        if (component.RewardTypeAlternate != null) // AS
         {
             var altRewardPrototype = _protoMan.Index<StackPrototype>(component.RewardTypeAlternate); // AS: Allow alt reward currencies
             var altStackUid = _stack.Spawn(altReward, altRewardPrototype, args.Actor.ToCoordinates()); // AS: Allow alt reward currencies
@@ -305,12 +318,15 @@ public sealed partial class ContrabandTurnInSystem : SharedContrabandTurnInSyste
         }
         GetPalletGoods(gridUid, ent, out _, out _, out _, out var toRegister); // AS: Allow alt reward currencies
 
-        // Award SCUs
-        var stackPrototype = _protoMan.Index<StackPrototype>(ent.Comp.RewardType);
-        // 1 SCU per registered item
-        var stackUid = _stack.Spawn(toRegister.Count, stackPrototype, _scuOutput.ToCoordinates());
+        // Award Primary currency (Probably SCU's) if we have one
+        if (ent.Comp.RewardType != null)
+        {
+            var stackPrototype = _protoMan.Index<StackPrototype>(ent.Comp.RewardType);
+            // 1 SCU per registered item
+            var stackUid = _stack.Spawn(toRegister.Count, stackPrototype, _scuOutput.ToCoordinates());
 
-        _transform.SetLocalRotation(stackUid, Angle.Zero); // Orient these to grid north instead of map north
+            _transform.SetLocalRotation(stackUid, Angle.Zero); // Orient these to grid north instead of map north
+        }
 
         //Exchange each item for their registered counterpart
         foreach (var oldEnt in toRegister)

--- a/Content.Server/_NF/Contraband/Systems/ContrabandTurnInSystem.cs
+++ b/Content.Server/_NF/Contraband/Systems/ContrabandTurnInSystem.cs
@@ -266,7 +266,7 @@ public sealed partial class ContrabandTurnInSystem : SharedContrabandTurnInSyste
         var outputQuery = EntityQueryEnumerator<ScuOutputComponent, TransformComponent>(); // Begin AS: Makes pirate contraband selling usable
         var output = uid.ToCoordinates();
         var outputSent = false;
-        while (outputQuery.MoveNext(out var _, out var xform))
+        while (outputQuery.MoveNext(out var _, out var xform)) // If theres an entity with an ScuOutputComponent, we want to try and send the primary currency to that first
         {
             if (xform.GridUid == gridUid)
             {
@@ -275,10 +275,10 @@ public sealed partial class ContrabandTurnInSystem : SharedContrabandTurnInSyste
             }
         }
 
-        if (component.RewardType != null) 
+        if (component.RewardType != null) // If we have a primary reward, spawn it
         {
-            var rewardPrototype = _protoMan.Index<StackPrototype>(component.RewardType); // AS: Allow alt reward currencies
-            var stackUid = _stack.Spawn(reward, rewardPrototype, output); // AS: Allow alt reward currencies
+            var rewardPrototype = _protoMan.Index<StackPrototype>(component.RewardType);
+            var stackUid = _stack.Spawn(reward, rewardPrototype, output);
             if (outputSent == false)
             {
                 if (!_hands.TryPickupAnyHand(args.Actor, stackUid)) // If there wasn't a a ScuOutputComponent to send these too, try to pick them up
@@ -291,12 +291,12 @@ public sealed partial class ContrabandTurnInSystem : SharedContrabandTurnInSyste
 
         }
 
-        if (component.RewardTypeAlternate != null) // AS
+        if (component.RewardTypeAlternate != null) // If we have an alternate currency, spawn it
         {
-            var altRewardPrototype = _protoMan.Index<StackPrototype>(component.RewardTypeAlternate); // AS: Allow alt reward currencies
-            var altStackUid = _stack.Spawn(altReward, altRewardPrototype, args.Actor.ToCoordinates()); // AS: Allow alt reward currencies
+            var altRewardPrototype = _protoMan.Index<StackPrototype>(component.RewardTypeAlternate);
+            var altStackUid = _stack.Spawn(altReward, altRewardPrototype, args.Actor.ToCoordinates());
             if (!_hands.TryPickupAnyHand(args.Actor, altStackUid))
-                _transform.SetLocalRotation(altStackUid, Angle.Zero); // Orient these to grid north instead of map north
+                _transform.SetLocalRotation(altStackUid, Angle.Zero); // Orient these to grid north instead of map north if we can't pick them up
         } // End AS
         UpdatePalletConsoleInterface(uid, component);
     }

--- a/Content.Shared/_NF/Contraband/BUI/ContrabandPalletConsoleInterfaceState.cs
+++ b/Content.Shared/_NF/Contraband/BUI/ContrabandPalletConsoleInterfaceState.cs
@@ -9,6 +9,12 @@ public sealed class ContrabandPalletConsoleInterfaceState : BoundUserInterfaceSt
     /// estimated appraised value of all the contraband on top of pallets on the same grid as the console
     /// </summary>
     public int Appraisal;
+    
+    // AS: Allow alt reward currencies
+    /// <summary>
+    /// estimated appraised value of all the contraband on top of pallets on the same grid as the console, in alternate currency
+    /// </summary>
+    public int AltAppraisal;
 
     /// <summary>
     /// number of contraband entities on top of pallets on the same grid as the console
@@ -26,9 +32,10 @@ public sealed class ContrabandPalletConsoleInterfaceState : BoundUserInterfaceSt
     public bool Enabled;
 
     // Aurora - added unregistered
-    public ContrabandPalletConsoleInterfaceState(int appraisal, int count, int unregistered, bool enabled)
+    public ContrabandPalletConsoleInterfaceState(int appraisal, int altAppraisal, int count, int unregistered, bool enabled)
     {
         Appraisal = appraisal;
+        AltAppraisal = altAppraisal;
         Count = count;
         Unregistered = unregistered;
         Enabled = enabled;

--- a/Content.Shared/_NF/Contraband/Components/ContrabandPalletComponent.cs
+++ b/Content.Shared/_NF/Contraband/Components/ContrabandPalletComponent.cs
@@ -14,7 +14,7 @@ public sealed partial class ContrabandPalletConsoleComponent : Component
     public string RewardType = "FrontierUplinkCoin";
 
     [ViewVariables(VVAccess.ReadWrite), DataField("altCashType", serverOnly: true, customTypeSerializer: typeof(PrototypeIdSerializer<StackPrototype>))]
-    public string RewardTypeAlternate = "ExchangeCoin"; // AS: Allow alt reward currencies
+    public string RewardTypeAlternate = string.Empty; // AS: Allow alt reward currencies
 
     [DataField]
     public SoundSpecifier ErrorSound = new SoundCollectionSpecifier("CargoError"); // Aurora: add deny sound

--- a/Content.Shared/_NF/Contraband/Components/ContrabandPalletComponent.cs
+++ b/Content.Shared/_NF/Contraband/Components/ContrabandPalletComponent.cs
@@ -10,11 +10,20 @@ namespace Content.Shared._NF.Contraband.Components;
 [Access(typeof(SharedContrabandTurnInSystem))]
 public sealed partial class ContrabandPalletConsoleComponent : Component
 {
-    [ViewVariables(VVAccess.ReadWrite), DataField("cashType", serverOnly: true, customTypeSerializer: typeof(PrototypeIdSerializer<StackPrototype>))]
-    public string RewardType = "FrontierUplinkCoin";
 
+    /// <summary>
+    /// The primary currency that should be reward. Tries to send it to an entity with a <see cref="ScuOutputComponent"/> first, then the triggering entities hand, and if both of those fail, spawns the coins on the console.
+    /// Also determines what currency is given as a registration reward.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite), DataField("cashType", serverOnly: true, customTypeSerializer: typeof(PrototypeIdSerializer<StackPrototype>))]
+    public string? RewardType = null;
+
+    // AS
+    /// <summary>
+    /// The reward that should be sent to the triggering entities hand, or spawn on the console if it can't
+    /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField("altCashType", serverOnly: true, customTypeSerializer: typeof(PrototypeIdSerializer<StackPrototype>))]
-    public string RewardTypeAlternate = string.Empty; // AS: Allow alt reward currencies
+    public string? RewardTypeAlternate = null; // AS: Allow alt reward currencies
 
     [DataField]
     public SoundSpecifier ErrorSound = new SoundCollectionSpecifier("CargoError"); // Aurora: add deny sound

--- a/Content.Shared/_NF/Contraband/Components/ContrabandPalletComponent.cs
+++ b/Content.Shared/_NF/Contraband/Components/ContrabandPalletComponent.cs
@@ -10,7 +10,7 @@ namespace Content.Shared._NF.Contraband.Components;
 [Access(typeof(SharedContrabandTurnInSystem))]
 public sealed partial class ContrabandPalletConsoleComponent : Component
 {
-
+    // AS
     /// <summary>
     /// The primary currency that should be reward. Tries to send it to an entity with a <see cref="ScuOutputComponent"/> first, then the triggering entities hand, and if both of those fail, spawns the coins on the console.
     /// Also determines what currency is given as a registration reward.

--- a/Content.Shared/_NF/Contraband/Components/ContrabandPalletComponent.cs
+++ b/Content.Shared/_NF/Contraband/Components/ContrabandPalletComponent.cs
@@ -13,8 +13,8 @@ public sealed partial class ContrabandPalletConsoleComponent : Component
     [ViewVariables(VVAccess.ReadWrite), DataField("cashType", serverOnly: true, customTypeSerializer: typeof(PrototypeIdSerializer<StackPrototype>))]
     public string RewardType = "FrontierUplinkCoin";
 
-    [DataField]
-    public EntProtoId RewardCashPrototype = "ExchangeCoin"; // SpaceCash5000 > ExchangeCoin | switched from cash to ExchangeCoin as economy experiment - Aurora
+    [ViewVariables(VVAccess.ReadWrite), DataField("altCashType", serverOnly: true, customTypeSerializer: typeof(PrototypeIdSerializer<StackPrototype>))]
+    public string RewardTypeAlternate = "ExchangeCoin"; // AS: Allow alt reward currencies
 
     [DataField]
     public SoundSpecifier ErrorSound = new SoundCollectionSpecifier("CargoError"); // Aurora: add deny sound

--- a/Resources/Locale/en-US/_NF/contraband/contraband-exchange-console.ftl
+++ b/Resources/Locale/en-US/_NF/contraband/contraband-exchange-console.ftl
@@ -3,6 +3,8 @@
 contraband-pallet-console-menu-title = Contraband Exchange
 # Aurora - FUC > SCU
 contraband-console-menu-points-amount = {$amount} SCU
+# AS: Allow alt reward currencies
+contraband-console-menu-points-amount-alt = {$altAmount} EC
 contraband-pallet-menu-no-goods-text = No contraband detected
 contraband-pallet-menu-appraisal-label = Estimated Value:{" "}
 contraband-pallet-menu-count-label = Number of items:{" "}

--- a/Resources/Prototypes/_AS/Contraband/contraband_classes.yml
+++ b/Resources/Prototypes/_AS/Contraband/contraband_classes.yml
@@ -13,4 +13,41 @@
     severity: Class2Unregistered
     turnInValues: &twoFUC
       FrontierUplinkCoin: 2
-      ExchangeCoin: 1
+      ExchangeCoin: 2
+
+# For Van to fill out later
+# - type: entity 
+#  id: SLEContrabandReturnable1
+#  abstract: true
+#  components:
+#  - type: Contraband
+#    severity: {Fill this out Van}
+#    turnInValues: 
+#      FrontierUplinkCoin: 1
+
+# - type: entity 
+#  id: SLEContrabandReturnable3
+#  abstract: true
+#  components:
+#  - type: Contraband
+#    severity: {Fill this out Van}
+#    turnInValues: 
+#      FrontierUplinkCoin: 3
+
+# - type: entity 
+#  id: SLEContrabandReturnable5
+#  abstract: true
+#  components:
+#  - type: Contraband
+#    severity: {Fill this out Van}
+#    turnInValues: 
+#      FrontierUplinkCoin: 5
+
+# - type: entity 
+#  id: SLEContrabandReturnable10
+#  abstract: true
+#  components:
+#  - type: Contraband
+#    severity: {Fill this out Van}
+#    turnInValues: 
+#      FrontierUplinkCoin: 10

--- a/Resources/Prototypes/_AS/Contraband/contraband_classes.yml
+++ b/Resources/Prototypes/_AS/Contraband/contraband_classes.yml
@@ -13,3 +13,4 @@
     severity: Class2Unregistered
     turnInValues: &twoFUC
       FrontierUplinkCoin: 2
+      ExchangeCoin: 1

--- a/Resources/Prototypes/_NF/Entities/Objects/base_contraband.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/base_contraband.yml
@@ -67,7 +67,7 @@
   components:
   - type: Contraband
     severity: Class2Expedition
-    turnInValues: &oneFUC
+    turnInValues: 
       FrontierUplinkCoin: 1
       ExchangeCoin: 1 # AS
       Doubloon: 1
@@ -110,7 +110,10 @@
   abstract: true
   components:
   - type: Contraband
-    turnInValues: *oneFUC
+    turnInValues: 
+      FrontierUplinkCoin: 1
+      ExchangeCoin: 1 # AS
+      Doubloon: 1
 
 - type: entity
   parent: BaseC3ContrabandUnredeemable
@@ -134,7 +137,10 @@
   abstract: true
   components:
   - type: Contraband
-    turnInValues: *oneFUC
+    turnInValues:
+      FrontierUplinkCoin: 1
+      ExchangeCoin: 1 # AS
+      Doubloon: 1
 
 - type: entity
   parent: BaseC3CultContraband
@@ -186,7 +192,10 @@
   abstract: true
   components:
   - type: Contraband
-    turnInValues: *oneFUC
+    turnInValues: 
+      FrontierUplinkCoin: 1
+      ExchangeCoin: 1 # AS
+      Doubloon: 1
 
 - type: entity
   parent: BaseC3ContrabandUnredeemable
@@ -203,7 +212,10 @@
   components:
   - type: Contraband
     severity: Class3Wizard
-    turnInValues: *oneFUC
+    turnInValues: 
+      FrontierUplinkCoin: 1
+      ExchangeCoin: 1 # AS
+      Doubloon: 1
 # endregion
 
 # region Class 3 Mobs

--- a/Resources/Prototypes/_NF/Entities/Objects/base_contraband.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/base_contraband.yml
@@ -69,6 +69,7 @@
     severity: Class2Expedition
     turnInValues: &oneFUC
       FrontierUplinkCoin: 1
+      ExchangeCoin: 1 # AS
       Doubloon: 1
 
 - type: entity
@@ -100,6 +101,7 @@
     severity: Class3Expedition
     turnInValues:
       FrontierUplinkCoin: 2
+      ExchangeCoin: 2 # AS
       Doubloon: 2
 
 - type: entity
@@ -159,6 +161,7 @@
   - type: Contraband
     turnInValues:
       FrontierUplinkCoin: 1
+      ExchangeCoin: 1 # AS
       Doubloon: 0
 
 - type: entity

--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers.yml
@@ -122,6 +122,7 @@
     - map: [ "enum.WiresVisualLayers.MaintenancePanel" ]
       state: generic_panel_open
   - type: ContrabandPalletConsole
+    cashType: FrontierUplinkCoin # AS
     altCashType: ExchangeCoin
   - type: ActivatableUI
     key: enum.ContrabandPalletConsoleUiKey.Contraband
@@ -316,7 +317,7 @@
 
 - type: entity
   name: plunder exchange computer
-  parent: [BaseStructureDisableToolUse, BaseStructureIndestructible, BaseComputer] # AS: I hate parenting
+  parent: ComputerContrabandPalletConsole
   id: ComputerContrabandPalletConsolePirate
   description: Fence yer ill-gotten goods here! And keep yer pile orderly.
   components:
@@ -339,6 +340,7 @@
     key: enum.ContrabandPalletConsoleUiKey.Contraband
   - type: ContrabandPalletConsole
     cashType: Doubloon
+    altCashType: Null
     faction: Pirates
     licenseRequired: Null
     locStringPrefix: pirate-

--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers.yml
@@ -335,7 +335,8 @@
   - type: Computer
     board: Null # Really shouldn't spawn anything on destruction
   - type: ContrabandPalletConsole
-    cashType: Doubloon
+    cashType: "Doubloon" # AS
+    altCashType: "" # AS
     faction: Pirates
     licenseRequired: Null
     locStringPrefix: pirate-

--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers.yml
@@ -122,6 +122,7 @@
     - map: [ "enum.WiresVisualLayers.MaintenancePanel" ]
       state: generic_panel_open
   - type: ContrabandPalletConsole
+    altCashType: ExchangeCoin
   - type: ActivatableUI
     key: enum.ContrabandPalletConsoleUiKey.Contraband
   - type: AccessReader
@@ -335,8 +336,7 @@
   - type: Computer
     board: Null # Really shouldn't spawn anything on destruction
   - type: ContrabandPalletConsole
-    cashType: "Doubloon" # AS
-    altCashType: "" # AS
+    cashType: Doubloon
     faction: Pirates
     licenseRequired: Null
     locStringPrefix: pirate-

--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers.yml
@@ -122,8 +122,8 @@
     - map: [ "enum.WiresVisualLayers.MaintenancePanel" ]
       state: generic_panel_open
   - type: ContrabandPalletConsole
-    cashType: FrontierUplinkCoin # AS
-    altCashType: ExchangeCoin
+    cashType: FrontierUplinkCoin
+    altCashType: ExchangeCoin # AS
   - type: ActivatableUI
     key: enum.ContrabandPalletConsoleUiKey.Contraband
   - type: AccessReader
@@ -336,11 +336,9 @@
       state: generic_panel_open
   - type: Computer
     board: Null # Really shouldn't spawn anything on destruction
-  - type: ActivatableUI # AS: Things it inheritated from its former parent
-    key: enum.ContrabandPalletConsoleUiKey.Contraband
   - type: ContrabandPalletConsole
     cashType: Doubloon
-    altCashType: Null
+    altCashType: Null # AS
     faction: Pirates
     licenseRequired: Null
     locStringPrefix: pirate-

--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers.yml
@@ -316,7 +316,7 @@
 
 - type: entity
   name: plunder exchange computer
-  parent: ComputerContrabandPalletConsole
+  parent: [BaseStructureDisableToolUse, BaseStructureIndestructible, BaseComputer] # AS: I hate parenting
   id: ComputerContrabandPalletConsolePirate
   description: Fence yer ill-gotten goods here! And keep yer pile orderly.
   components:
@@ -335,6 +335,8 @@
       state: generic_panel_open
   - type: Computer
     board: Null # Really shouldn't spawn anything on destruction
+  - type: ActivatableUI # AS: Things it inheritated from its former parent
+    key: enum.ContrabandPalletConsoleUiKey.Contraband
   - type: ContrabandPalletConsole
     cashType: Doubloon
     faction: Pirates

--- a/Resources/Prototypes/_NF/Entities/Structures/Specific/TradingCrates/base.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Specific/TradingCrates/base.yml
@@ -117,6 +117,7 @@
   - type: Contraband
     turnInValues:
       FrontierUplinkCoin: 3
+      ExchangeCoin: 3 # AS
       Doubloon: 2
   - type: ShipyardSellCondition
     blockSale: false # AS True>False


### PR DESCRIPTION
## About the PR
Allows for seperate reward values for contraband turn ins for EC and SCU

Also fixes the Pirate contraband exchange console to be workable

## Why / Balance
I didn't ask Van that many questions before I agreed to work on it

## Technical details
C# modifications, YAML additions

## How to test
1. Find contraband
2. Turn it in
3. Watch as you potentially get differing amounts of EC and SCU from the transaction

## Media
N/A

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).


## Breaking changes
Shouldn't be any. I hope.

**Changelog**
:cl:
- tweak: Contraband can now be turned in for differing amounts of EC and SCU.
- fix: The Pirate Contraband Console works again.

