### PR TITLE
No Getting Lost in Subspace

### DIFF
--- a/Content.Client/_AS/Shuttles/Systems/FTLFallingVisualSystem.cs
+++ b/Content.Client/_AS/Shuttles/Systems/FTLFallingVisualSystem.cs
@@ -1,0 +1,82 @@
+using Content.Shared._AS.Shuttles.Components;
+using Robust.Client.Animations;
+using Robust.Client.GameObjects;
+using Robust.Shared.Animations;
+
+namespace Content.Client._AS.Shuttles.Systems;
+
+/// <summary>
+///     Handles the falling animation for entities that fall into a chasm.
+/// </summary>
+public sealed class FTLFallingVisualsSystem : EntitySystem
+{
+    [Dependency] private readonly AnimationPlayerSystem _anim = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
+
+    private readonly string _chasmFallAnimationKey = "chasm_fall";
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<FTLFallingComponent, ComponentInit>(OnComponentInit);
+        SubscribeLocalEvent<FTLFallingComponent, ComponentRemove>(OnComponentRemove);
+    }
+
+    private void OnComponentInit(EntityUid uid, FTLFallingComponent component, ComponentInit args)
+    {
+        if (!TryComp<SpriteComponent>(uid, out var sprite) ||
+            TerminatingOrDeleted(uid))
+        {
+            return;
+        }
+
+        component.OriginalScale = sprite.Scale;
+
+        if (!TryComp<AnimationPlayerComponent>(uid, out var player))
+            return;
+
+        if (_anim.HasRunningAnimation(player, _chasmFallAnimationKey))
+            return;
+
+        _anim.Play((uid, player), GetFallingAnimation(component), _chasmFallAnimationKey);
+    }
+
+    private void OnComponentRemove(EntityUid uid, FTLFallingComponent component, ComponentRemove args)
+    {
+        if (!TryComp<SpriteComponent>(uid, out var sprite))
+            return;
+
+        _sprite.SetScale((uid, sprite), component.OriginalScale);
+
+        if (!TryComp<AnimationPlayerComponent>(uid, out var player))
+            return;
+
+        if (_anim.HasRunningAnimation(player, _chasmFallAnimationKey))
+            _anim.Stop((uid, player), _chasmFallAnimationKey);
+    }
+
+    private Animation GetFallingAnimation(FTLFallingComponent component)
+    {
+        var length = component.AnimationTime;
+
+        return new Animation()
+        {
+            Length = length,
+            AnimationTracks =
+            {
+                new AnimationTrackComponentProperty()
+                {
+                    ComponentType = typeof(SpriteComponent),
+                    Property = nameof(SpriteComponent.Scale),
+                    KeyFrames =
+                    {
+                        new AnimationTrackProperty.KeyFrame(component.OriginalScale, 0.0f),
+                        new AnimationTrackProperty.KeyFrame(component.AnimationScale, length.Seconds),
+                    },
+                    InterpolationMode = AnimationInterpolationMode.Cubic
+                }
+            }
+        };
+    }
+}

--- a/Content.Client/_AS/Shuttles/Systems/FTLFallingVisualSystem.cs
+++ b/Content.Client/_AS/Shuttles/Systems/FTLFallingVisualSystem.cs
@@ -6,7 +6,7 @@ using Robust.Shared.Animations;
 namespace Content.Client._AS.Shuttles.Systems;
 
 /// <summary>
-///     Handles the falling animation for entities that fall into a chasm.
+///     Handles the falling animation for entities that fall into FTL SPace.
 /// </summary>
 public sealed class FTLFallingVisualsSystem : EntitySystem
 {

--- a/Content.Server/_AS/Shuttles/Systems/FTLFallingSystem.cs
+++ b/Content.Server/_AS/Shuttles/Systems/FTLFallingSystem.cs
@@ -1,0 +1,116 @@
+using System.Numerics;
+using Content.Shared.ActionBlocker;
+using Content.Shared.Buckle.Components;
+using Content.Shared.Movement.Events;
+using Content.Shared.StepTrigger.Systems;
+using Content.Shared._AS.Shuttles.Components;
+using Content.Shared.Shuttles.Components;
+using Content.Shared.Damage;
+using Content.Shared.GameTicking;
+using Content.Shared.Mind.Components;
+using Content.Server.GameTicking;
+using Robust.Shared.Audio;
+using Robust.Shared.Audio.Systems;
+using Robust.Shared.Network;
+using Robust.Shared.Map.Components;
+using Robust.Shared.Map;
+using Robust.Shared.Log;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Random;
+using Robust.Shared.Physics;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Timing;
+using Robust.Shared.Physics.Systems;
+using Robust.Server.GameObjects;
+
+
+namespace Content.Server._AS.Shuttles.Systems;
+
+/// <summary>
+///     Handles making entities fall into chasms when stepped on.
+/// </summary>
+public sealed class FTLFallingSystem : EntitySystem
+{
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly ActionBlockerSystem _blocker = default!;
+    [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly GameTicker _gameTicker = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly TransformSystem _transform = default!;
+    [Dependency] private readonly SharedMapSystem _mapSystem = default!;
+    [Dependency] private readonly DamageableSystem _damageable = default!;
+    [Dependency] private readonly SharedPhysicsSystem _physics = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<EntParentChangedMessage>(OnEntityParentChanged);
+        SubscribeLocalEvent<FTLFallingComponent, UpdateCanMoveEvent>(OnUpdateCanMove);
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var query = EntityQueryEnumerator<FTLFallingComponent, MindContainerComponent>();
+        while (query.MoveNext(out var uid, out var falling, out _))
+        {
+            if (_timing.CurTime < falling.NextFallingTime)
+                continue;
+
+            RemComp<FTLFallingComponent>(uid);
+            if (!TryComp<TransformComponent>(uid, out var xform))
+                return;
+
+            if (!_mapSystem.TryGetMap(_gameTicker.DefaultMap, out var mapUid))
+            {
+                Log.Error($"Could not get DefaultMap EntityUID, entity {uid} may be stuck in FTL Space.");
+                return;
+            }
+
+            var destination = new EntityCoordinates(mapUid.Value, _random.NextVector2(falling.MinimumDistance, falling.MaximumDistance));
+            var damageAmount = new DamageSpecifier()
+            {
+                DamageDict = { ["Slash"] = 15, ["Blunt"] = 25 }  // A small brick
+            };
+            // Make them stop moving
+            if (TryComp<PhysicsComponent>(uid, out var physics))
+            {
+                var fixtures = Comp<FixturesComponent>(uid);
+                _physics.SetLinearVelocity(uid, Vector2.Zero, manager: fixtures, body: physics);
+            }
+            // Let them move again
+            _blocker.UpdateCanMove(uid);
+            // Then teleport them back to reality
+            _transform.SetCoordinates(uid, xform, destination);
+            _transform.AttachToGridOrMap(uid, xform);
+            // Then hit them with a brick
+            _damageable.TryChangeDamage(uid, damageAmount, false);
+        }
+    }
+
+    private void OnEntityParentChanged(ref EntParentChangedMessage args)
+    {
+        if (!HasComp<FTLMapComponent>(args.Transform.ParentUid) || HasComp<MapGridComponent>(args.Entity))
+            return;
+        Log.Debug($"{args.Entity} went onto the FTL Map");
+        StartFalling(args.Entity);
+    }
+
+    public void StartFalling(EntityUid tripper, bool playSound = true)
+    {
+        var falling = AddComp<FTLFallingComponent>(tripper);
+
+        falling.NextFallingTime = _timing.CurTime + falling.FallingTime;
+        _blocker.UpdateCanMove(tripper);
+
+        if (playSound)
+            _audio.PlayPvs(new SoundPathSpecifier("/Audio/Effects/falling.ogg"), tripper);
+    }
+
+    private void OnUpdateCanMove(EntityUid uid, FTLFallingComponent component, UpdateCanMoveEvent args)
+    {
+        args.Cancel();
+    }
+}

--- a/Content.Server/_AS/Shuttles/Systems/FTLFallingSystem.cs
+++ b/Content.Server/_AS/Shuttles/Systems/FTLFallingSystem.cs
@@ -27,7 +27,7 @@ using Robust.Server.GameObjects;
 namespace Content.Server._AS.Shuttles.Systems;
 
 /// <summary>
-///     Handles making entities fall into chasms when stepped on.
+///     Handles making entities fall into FTL Space when stepping into space during transit
 /// </summary>
 public sealed class FTLFallingSystem : EntitySystem
 {

--- a/Content.Shared/_AS/Shuttles/Components/FTLFallingComponent.cs
+++ b/Content.Shared/_AS/Shuttles/Components/FTLFallingComponent.cs
@@ -1,0 +1,50 @@
+using System.Numerics;
+using Robust.Shared.GameStates;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+
+namespace Content.Shared._AS.Shuttles.Components;
+
+/// <summary>
+///     Added to entities which have started falling into a chasm.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentPause]
+public sealed partial class FTLFallingComponent : Component
+{
+    /// <summary>
+    ///     Time it should take for the falling animation (scaling down) to complete.
+    /// </summary>
+    [DataField("animationTime")]
+    public TimeSpan AnimationTime = TimeSpan.FromSeconds(1.5f);
+
+    /// <summary>
+    ///     Time it should take in seconds for the entity to actually fall
+    /// </summary>
+    [DataField("fallingTime")]
+    public TimeSpan FallingTime = TimeSpan.FromSeconds(1.8f);
+
+    [DataField("nextFallingTime", customTypeSerializer:typeof(TimeOffsetSerializer))]
+    [AutoPausedField]
+    public TimeSpan NextFallingTime = TimeSpan.Zero;
+
+    /// <summary>
+    ///     The minimum distance you can reappear from the center of the map
+    /// </summary>
+    [DataField("minimumDistance")]
+    public float MinimumDistance = 2000f;
+
+    /// <summary>
+    ///     The minimum distance you can reappear from the center of the map
+    /// </summary>
+    [DataField("maximumDistance")]
+    public float MaximumDistance = 4000;
+
+    /// <summary>
+    ///     Original scale of the object so it can be restored
+    /// </summary>
+    public Vector2 OriginalScale = Vector2.Zero;
+
+    /// <summary>
+    ///     Scale that the animation should bring entities to.
+    /// </summary>
+    public Vector2 AnimationScale = new Vector2(0.01f, 0.01f);
+}

--- a/Content.Shared/_AS/Shuttles/Components/FTLFallingComponent.cs
+++ b/Content.Shared/_AS/Shuttles/Components/FTLFallingComponent.cs
@@ -5,7 +5,7 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 namespace Content.Shared._AS.Shuttles.Components;
 
 /// <summary>
-///     Added to entities which have started falling into a chasm.
+///     Added to entities which have started falling into FTL Space.
 /// </summary>
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentPause]
 public sealed partial class FTLFallingComponent : Component


### PR DESCRIPTION
## About the PR
Falling off of your ship while in space now teleports you back somewhere to the main map

## Why / Balance
Getting stuck forever in FTL space is bad

## Technical details
New systems and accompanying components, mostly co-opted from Chasm System

## How to test
1. FTL
2. Act on the Call of the Void
3. Faceplant back into reality

## Media
N/A

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).


## Breaking changes
N/A

**Changelog**
:cl:
- add: Added a new system that shunts you back into reality if you fall out of your ship during FTL.


