### PR TITLE
Make the Exped Saviour System fire earlier

### DIFF
--- a/Content.Server/Salvage/SalvageSystem.Runner.cs
+++ b/Content.Server/Salvage/SalvageSystem.Runner.cs
@@ -323,7 +323,7 @@ public sealed partial class SalvageSystem
                 }
             }
 
-            if (remaining < TimeSpan.FromSeconds(1)) // AS: Get players and non-hostile ghost roles left on the expedition and yeet them onto the shuttle before we delete the map
+            if (remaining < TimeSpan.FromSeconds(2.5)) // AS: Get players and non-hostile ghost roles left on the expedition and yeet them onto the shuttle before we delete the map
             {
                 var shuttleQuery = AllEntityQuery<ShuttleComponent, TransformComponent>();
 


### PR DESCRIPTION
## About the PR
Changed the time where the ESS teleported your bodies back onto the ship to be earlier by 1.5 seconds

## Why / Balance
There was apparently a brief window where it wouldn't save you, made it trigger earlier so it hopefully doesn't happen again

## Technical details
One line c# change

## How to test
1. Go one an exped
2. Get lost
3. Get snapped back, hopefully

## Media
N/A

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.

## Breaking changes
N/A

**Changelog**

:cl:
- tweak: Made the Exped Saviour System trigger 1.5 seconds sooner to hopefully avoid any accidental body deletions.


