### PR TITLE
Make Bandolier Grid Based Storage

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -528,7 +528,7 @@
 # Belts without visualizers
 
 - type: entity
-  parent: [ClothingBeltStorageBase, BaseC1Contraband] # Frontier: BaseSecurityBartenderContraband<BaseC1Contraband Aurora's Song: ClothingBeltAmmoProviderBase <
+  parent: [ClothingBeltStorageBase, BaseC1Contraband] # Frontier: BaseSecurityBartenderContraband<BaseC1Contraband Aurora's Song: ClothingBeltAmmoProviderBase < ClothingBeltStorageBase
   id: ClothingBeltBandolier
   name: bandolier
   description: A bandolier for holding shotgun ammunition.


### PR DESCRIPTION


## About the PR
Changed Bandolier to use a storage system instead of be a glorified shell box

## Why / Balance
Allows for pulling of each individual shells, as well as more in depth storage.
Using grid based storage allows for quick-equip to pull individual shells and special shotgun "loads"
Changed whitelist to allow any item tagged "Cartridge" for bandoliers to work with revolvers, lever actions, shotguns, and any other individually loading firearm

## Technical details
Changes from BeltAmmoProvider to BeltStorage with a capacity of 20
Changes whitelist to Cartridge from ShellShotgun

## How to test
Open up bandolier and load any bullet type

## Media
<img width="696" height="266" alt="image" src="https://github.com/user-attachments/assets/2c24beb0-f6d6-43e1-b91a-a94f286f745f" />
<img width="587" height="443" alt="image" src="https://github.com/user-attachments/assets/158fb9bf-eb8e-4dfb-8876-385a6645e056" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
NA

**Changelog**
:cl:
- tweak: Changed bandolier to grid storage and allow any bullet