### PR TITLE
A few fixes and redundancies for ESS

### DIFF
--- a/Content.Server/Salvage/SalvageSystem.Runner.cs
+++ b/Content.Server/Salvage/SalvageSystem.Runner.cs
@@ -30,6 +30,9 @@ using Content.Server._NF.Salvage.Expeditions;
 using Content.Shared.Mind.Components; // AS
 using Content.Shared.Salvage; // AS
 using Content.Shared.Warps; // AS
+using Content.Shared.Buckle; // AS
+using Content.Shared.Buckle.Components; // AS
+using Content.Shared.Implants; // AS
 using Robust.Server.Player;// Coyote
 using Robust.Shared.Audio; // AS
 using Robust.Shared.Audio.Systems; //AS
@@ -47,6 +50,7 @@ public sealed partial class SalvageSystem
     [Dependency] private readonly GameTicker _gameTicker = default!; // Frontier
     [Dependency] private readonly DamageableSystem _damageable = default!; // AS
     [Dependency] private readonly IPlayerManager _players = default!; // Coyote
+    [Dependency] private readonly SharedBuckleSystem _buckle = default!; // AS
 
     private void InitializeRunner()
     {
@@ -335,8 +339,8 @@ public sealed partial class SalvageSystem
                                 continue;
 
                             // Get everyone we want to recover that is on the map and not on the shuttle
-                            var playerQuery = EntityQueryEnumerator<MindContainerComponent, MobStateComponent, TransformComponent>();
-                            while (playerQuery.MoveNext(out var quid, out var mindContainer, out var _, out var mobXform))
+                            var playerQuery = EntityQueryEnumerator<MindContainerComponent, TransformComponent>();
+                            while (playerQuery.MoveNext(out var quid, out var mindContainer, out var mobXform))
                             {
                                 // If they aren't on the expedition map, don't want em
                                 if (mobXform.MapUid != uid)
@@ -360,30 +364,44 @@ public sealed partial class SalvageSystem
                                     var hostileFactions = npcFaction.HostileFactions;
                                     if (hostileFactions.Contains("NanoTrasen")) // TODO: move away from hardcoded faction
                                         continue;
+
                                 }
-                                // If we got this far, we want to try and find a warp point on their ship and warp them to it
-                                var warpQuery = EntityQueryEnumerator<WarpPointComponent, TransformComponent>();
-                                while (warpQuery.MoveNext(out var wuid, out var _, out var warpXform))
+
+                                // If we got this far, we want to try and find a destination on their ship and warp them to it
+                                var strapQuery = EntityQueryEnumerator<StrapComponent, TransformComponent>();
+                                while (strapQuery.MoveNext(out var suid, out var strapComp, out var strapXform)) // find an unnocupied bed/chair
                                 {
+                                    if (Transform(quid).GridUid == shuttleUid)
+                                        break;
+                                    if (Transform(suid).GridUid != shuttleUid)
+                                        continue;
+                                    if (strapComp.BuckledEntities.Count > 0)
+                                        continue;
+                                    Log.Debug($"Strap point found: {suid}");
+                                    SafetyWarp(quid, strapXform.Coordinates);
+                                    _buckle.TryBuckle(quid, null, suid);
+                                }
+
+                                var warpQuery = EntityQueryEnumerator<WarpPointComponent, TransformComponent>();
+                                while (warpQuery.MoveNext(out var wuid, out var _, out var warpXform)) // then try to find the ships warp point
+                                {
+                                    if (Transform(quid).GridUid == shuttleUid)
+                                        break;
                                     if (Transform(wuid).GridUid != shuttleUid)
                                         continue;
-                                    // first we ensure they are dead
-                                    if (_mobState.IsAlive(quid))
-                                    {
-                                        // Apply a large bricks worth of damage
-                                        var damageAmount = new DamageSpecifier()
-                                        {
-                                            DamageDict = { ["Slash"] = 75, ["Blunt"] = 75, ["Heat"] = 75 }  // If you are still alive after this you deserve it
-                                        };
-                                        _damageable.TryChangeDamage(quid, damageAmount, true);
-                                    }
-                                    // now teleport them to the first one we found
-                                    _transform.SetCoordinates(quid, mobXform, warpXform.Coordinates);
-                                    _transform.AttachToGridOrMap(quid, mobXform);
-                                    Spawn("EffectFlashBluespaceQuiet", mobXform.Coordinates);
-                                    break;
+                                    Log.Debug($"Warp point found: {wuid}");
+                                    SafetyWarp(quid, warpXform.Coordinates);
                                 }
-                            } 
+
+                                // We're out of options, just try and dump them in space
+                                if (!_mapSystem.TryGetMap(_gameTicker.DefaultMap, out var mapUid))
+                                {
+                                    Log.Error($"Could not get DefaultMap EntityUID, entity {quid} may be deleted.");
+                                    return;
+                                    var fallback = new EntityCoordinates(mapUid.Value, _random.NextVector2(2000f, 2000f));
+                                    SafetyWarp(quid, fallback);
+                                }
+                            }
                         }
                     }
                 }
@@ -391,6 +409,37 @@ public sealed partial class SalvageSystem
 
             if (remaining < TimeSpan.Zero)
             {
+                var playerQuery = EntityQueryEnumerator<MindContainerComponent, TransformComponent>(); // AS: No idea whats causing people to be RR, so I'm adding redudancies out the ass.
+                while (playerQuery.MoveNext(out var quid, out var mindContainer, out var mobXform)) // Yes, this is pretty much an exact duplicate of the above code but with only the fallback as the destination
+                {                                                                                   // I'd try and make it cleaner but I'm slightly exasperated.
+                    // If they aren't on the expedition map, don't want em
+                    if (mobXform.MapUid != uid)
+                        continue;
+
+                    // Not player controlled at any point
+                    if (!mindContainer.HasMind)
+                        continue;
+
+                    // NPC, definitely not a person
+                    if (HasComp<ActiveNPCComponent>(quid) || HasComp<NFSalvageMobRestrictionsComponent>(quid))
+                        continue;
+
+                    // Hostile ghost role, continue
+                    if (TryComp(quid, out NpcFactionMemberComponent? npcFaction))
+                    {
+                        var hostileFactions = npcFaction.HostileFactions;
+                        if (hostileFactions.Contains("NanoTrasen")) // TODO: move away from hardcoded faction
+                            continue;
+
+                    }
+                    if (!_mapSystem.TryGetMap(_gameTicker.DefaultMap, out var mapUid))
+                    {
+                        Log.Error($"Could not get DefaultMap EntityUID, entity {quid} may be deleted.");
+                        return;
+                        var fallback = new EntityCoordinates(mapUid.Value, _random.NextVector2(2000f, 2000f));
+                        SafetyWarp(quid, fallback);
+                    }
+                }
                 QueueDel(uid);
             }
         }
@@ -522,5 +571,32 @@ public sealed partial class SalvageSystem
         component.Stage = ExpeditionStage.FinalCountdown;
         component.EndTime = newEndTime;
     }
-}
 
+    private void SafetyWarp(EntityUid mobUid, EntityCoordinates warpDestination) // AS
+    {
+        Log.Debug($"Attempting to teleport {mobUid}");
+
+        // first we teleport them
+        var mobXform = Transform(mobUid);
+        _transform.SetCoordinates(mobUid, mobXform, warpDestination);
+        _transform.AttachToGridOrMap(mobUid, mobXform);
+        Spawn("EffectFlashBluespaceQuiet", mobXform.Coordinates);
+
+        // then we ensure they are 
+        if (_mobState.IsAlive(mobUid))
+        {
+            // Apply a large bricks worth of damage
+            var damageAmount = new DamageSpecifier()
+            {
+                DamageDict = { ["Slash"] = 75, ["Blunt"] = 75, ["Heat"] = 75 }  // If you are still alive after this you deserve it
+            };
+            _damageable.TryChangeDamage(mobUid, damageAmount, true);
+        }
+        else if (TryComp<MobStateComponent>(mobUid, out var mobState))
+        {
+
+            var deathrattleEvent = new ReTriggerRattleImplantEvent(mobUid, mobState.CurrentState);
+            RaiseLocalEvent(mobUid, deathrattleEvent);
+        }
+    }
+}

--- a/Content.Server/StationRecords/Systems/StationRecordsSystem.cs
+++ b/Content.Server/StationRecords/Systems/StationRecordsSystem.cs
@@ -429,7 +429,9 @@ public sealed class StationRecordsSystem : SharedStationRecordsSystem
             StationRecordFilterType.Job =>
                 !someRecord.JobTitle.ToLower().Contains(filterLowerCaseValue),
             StationRecordFilterType.Species =>
-                !someRecord.Species.ToLower().Contains(filterLowerCaseValue),
+                someRecord.Replicant // Misfit - Add (AS: Replicant) to species record searching
+                    ? !$"{someRecord.Species} replicant".ToLower().Contains(filterLowerCaseValue)
+                    : !someRecord.Species.ToLower().Contains(filterLowerCaseValue),
             StationRecordFilterType.Prints => someRecord.Fingerprint != null
                 && IsFilterWithSomeCodeValue(someRecord.Fingerprint, filterLowerCaseValue),
             StationRecordFilterType.DNA => someRecord.DNA != null

--- a/Content.Server/_AS/Shuttles/Systems/FTLFallingSystem.cs
+++ b/Content.Server/_AS/Shuttles/Systems/FTLFallingSystem.cs
@@ -8,7 +8,9 @@ using Content.Shared.Shuttles.Components;
 using Content.Shared.Damage;
 using Content.Shared.GameTicking;
 using Content.Shared.Mind.Components;
+using Content.Shared.Ghost;
 using Content.Server.GameTicking;
+using Content.Server.Pointing.Components;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Network;
@@ -93,6 +95,8 @@ public sealed class FTLFallingSystem : EntitySystem
     private void OnEntityParentChanged(ref EntParentChangedMessage args)
     {
         if (!HasComp<FTLMapComponent>(args.Transform.ParentUid) || HasComp<MapGridComponent>(args.Entity))
+            return;
+        if (HasComp<GhostComponent>(args.Entity) || HasComp<PointingArrowComponent>(args.Entity))
             return;
         Log.Debug($"{args.Entity} went onto the FTL Map");
         StartFalling(args.Entity);


### PR DESCRIPTION
## About the PR
Adds additional redundancies to the ESS to try and limit the amount of Round Removals that occur.

Adds checks to ensure ghosts or pointer arrows don't fall into FTL Space

Makes Replicants searchable as species in records consoles (ported from Harmony [1254](https://github.com/ss14-harmony/ss14-harmony/pull/1254)

## Why / Balance
Fixes good

## Technical details
Adds more possible destinations for the ESS to try and send you too, and adds a final attempt to save those stranded before the map gets queuedel'd

## How to test
1. Have a replicant
2. Try and search them up by species in a records console

1. Be in FTL space
2. Point outside
2.a Go outside as a ghost

1. Do an exped
2. Be left behind somehow
3. Get rescued (hopefully)

## Media
N/A

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes
N/A

**Changelog**
:cl:
- fix: Fixed ghosts and pointer entities falling into FTL
- fix: Fixed replicants being unsearchable via records
- fix: Attempts to fix instances of being left behind despite the ESS

