### PR TITLE
Alleyedit Fix

### DIFF
--- a/Resources/Maps/_AS/POI/the_alley.yml
+++ b/Resources/Maps/_AS/POI/the_alley.yml
@@ -1,11 +1,11 @@
 meta:
   format: 7
   category: Grid
-  engineVersion: 261.2.2
+  engineVersion: 267.4.0
   forkId: ""
   forkVersion: ""
-  time: 03/18/2026 03:09:46
-  entityCount: 5455
+  time: 03/26/2026 09:43:06
+  entityCount: 5459
 maps: []
 grids:
 - 1
@@ -1804,7 +1804,7 @@ entities:
             0: 8191
           4,5:
             0: 61697
-            2: 68
+            1: 68
           4,6:
             0: 30719
           4,7:
@@ -2064,7 +2064,7 @@ entities:
           6,-1:
             0: 136
           7,-4:
-            1: 1568
+            2: 1568
           4,-9:
             0: 61713
           5,-8:
@@ -2145,7 +2145,7 @@ entities:
             0: 306
           -6,-9:
             0: 51200
-            1: 16
+            2: 16
           -5,-8:
             0: 61184
           -5,-7:
@@ -2209,7 +2209,7 @@ entities:
           6,6:
             0: 4368
           -7,-9:
-            1: 3072
+            2: 3072
           -5,-9:
             0: 868
           -5,-10:
@@ -2325,7 +2325,7 @@ entities:
         - volume: 2500
           temperature: 293.15
           moles:
-          - 0
+          - 6666.982
           - 0
           - 0
           - 0
@@ -2340,7 +2340,7 @@ entities:
         - volume: 2500
           temperature: 293.15
           moles:
-          - 6666.982
+          - 0
           - 0
           - 0
           - 0
@@ -12794,6 +12794,21 @@ entities:
     - type: Transform
       pos: -5.5,-36.5
       parent: 1
+  - uid: 5381
+    components:
+    - type: Transform
+      pos: 1.5,21.5
+      parent: 1
+  - uid: 5383
+    components:
+    - type: Transform
+      pos: 2.5,21.5
+      parent: 1
+  - uid: 5454
+    components:
+    - type: Transform
+      pos: 3.5,21.5
+      parent: 1
 - proto: CableTerminal
   entities:
   - uid: 2610
@@ -15315,7 +15330,7 @@ entities:
       pos: -13.5,12.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -12661.37
+      secondsUntilStateChange: -12923.163
       state: Closing
     - type: DeviceNetwork
       deviceLists:
@@ -27705,37 +27720,43 @@ entities:
       parent: 1
 - proto: SignDirectionalCryo
   entities:
-  - uid: 5380
+  - uid: 5455
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -14.5,-22.7
+      pos: -14.5,-23.5
       parent: 1
-  - uid: 5381
+  - uid: 5456
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 4.5,-11.7
+      pos: 0.5,-24.5
       parent: 1
-  - uid: 5383
+  - uid: 5457
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 10.5,-19.7
+      pos: 4.5,-24.5
       parent: 1
-  - uid: 5454
+  - uid: 5459
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 0.5,-23.75
+      pos: 8.5,-11.5
       parent: 1
 - proto: SignDirectionalMed
   entities:
+  - uid: 4628
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-23.5
+      parent: 1
   - uid: 4714
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -14.5,-22.5
+      pos: 4.5,-11.5
       parent: 1
   - uid: 4751
     components:
@@ -27743,23 +27764,17 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -13.5,-5.5
       parent: 1
-  - uid: 5218
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 4.5,-11.5
-      parent: 1
   - uid: 5379
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 10.5,-19.5
+      rot: 1.5707963267948966 rad
+      pos: -14.5,-22.5
       parent: 1
-  - uid: 5455
+  - uid: 5458
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,-23.5
+      rot: 3.141592653589793 rad
+      pos: 4.5,-23.5
       parent: 1
 - proto: SignGravity
   entities:
@@ -28143,6 +28158,16 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -19.5,-18.5
+      parent: 1
+  - uid: 5218
+    components:
+    - type: Transform
+      pos: 1.5,-55.5
+      parent: 1
+  - uid: 5380
+    components:
+    - type: Transform
+      pos: -18.5,-9.5
       parent: 1
 - proto: StationMapBroken
   entities:
@@ -35076,7 +35101,7 @@ entities:
       pos: 29.5,1.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -23320.158
+      secondsUntilStateChange: -23581.95
       state: Opening
   - uid: 2765
     components:


### PR DESCRIPTION
## About the PR
Fix for previous PR
Made some cosmetic changes to the Alley, including revision to the engineering areas, rearrangement of the mass scanners, and placing tiles under doors where they are missing. Also added some cosmetic tiles to maints and pathways for variation. Decal work in main area. Signs added to alley to indicate location for med+cryo since a lot of players seem not to know where to find them. (Myself included)
Fixed #302 

## Why / Balance
Mass scanners were oriented incorrectly. Cosmetic improvements are subjective.

## Technical details
N/A

## How to test
Ensure the station can spawn in correctly and the power system functions.

## Media
<img width="719" height="384" alt="image" src="https://github.com/user-attachments/assets/af9e9300-9d95-410b-9909-ff0648224d2a" />
Missing power cables

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes
N/A (?)

**Changelog**
:cl: TurtleOfMen
- add: Med/Cryo signs in The Alley
- tweak: Major cosmetic changes to engineering in the Alley
- tweak: Main Alley room re-arranged and decorated
- tweak: Minor decal changes in Alley's medical area
- tweak: Minor cosmetic tile changes in Alley's maints and pathways
- fix: Fixed mass scanner orientation on The Alley
- fix: Fixed under-door missing tiles on The Alley