### PR TITLE
More AI related fixes

### DIFF
--- a/Content.Server/_AS/Shuttles/Systems/FTLFallingSystem.cs
+++ b/Content.Server/_AS/Shuttles/Systems/FTLFallingSystem.cs
@@ -9,6 +9,7 @@ using Content.Shared.Damage;
 using Content.Shared.GameTicking;
 using Content.Shared.Mind.Components;
 using Content.Shared.Ghost;
+using Content.Shared.Silicons.StationAi;
 using Content.Server.GameTicking;
 using Content.Server.Pointing.Components;
 using Robust.Shared.Audio;
@@ -96,7 +97,7 @@ public sealed class FTLFallingSystem : EntitySystem
     {
         if (!HasComp<FTLMapComponent>(args.Transform.ParentUid) || HasComp<MapGridComponent>(args.Entity))
             return;
-        if (HasComp<GhostComponent>(args.Entity) || HasComp<PointingArrowComponent>(args.Entity))
+        if (HasComp<GhostComponent>(args.Entity) || HasComp<PointingArrowComponent>(args.Entity) || HasComp<StationAiEyeComponent>(args.Entity))
             return;
         Log.Debug($"{args.Entity} went onto the FTL Map");
         StartFalling(args.Entity);

--- a/Content.Server/_Corvax/Respawn/Silicons/Borgs/AiRemoteControlSystem.cs
+++ b/Content.Server/_Corvax/Respawn/Silicons/Borgs/AiRemoteControlSystem.cs
@@ -244,7 +244,6 @@ public sealed class AiRemoteControlSystem : SharedAiRemoteControlSystem
             if (!ghostRole.ReregisterOnGhost || component.LifeStage > ComponentLifeStage.Running)
                 return;
 
-            Log.Error("Re-registering ghost role of parent AI");
             _ghostSystem.ReRegisterGhostRole(component.AiHolder.Value, ghostRole);
 
             component.AiHolder = null;

--- a/Content.Server/_Corvax/Respawn/Silicons/Borgs/AiRemoteControlSystem.cs
+++ b/Content.Server/_Corvax/Respawn/Silicons/Borgs/AiRemoteControlSystem.cs
@@ -137,6 +137,7 @@ public sealed class AiRemoteControlSystem : SharedAiRemoteControlSystem
                 activeRadio.Channels = [.. stationAiActiveRadio.Channels];
         }
 
+        stationAiHeldComp.CurrentConnectedEntity = entity; // AS: Moved because it was causing problems with ghost roles
         _mind.ControlMob(ai, entity);
         aiRemoteComp.AiHolder = ai;
         aiRemoteComp.LinkedMind = mindId;
@@ -148,7 +149,6 @@ public sealed class AiRemoteControlSystem : SharedAiRemoteControlSystem
         {
             _metaSystem.SetEntityName(entity, Comp<MetaDataComponent>(ai).EntityName + " Remote Chassis");
         }
-        stationAiHeldComp.CurrentConnectedEntity = entity;
 
         _stationAiSystem.SwitchRemoteEntityMode(stationAiCore, false);
 
@@ -244,6 +244,7 @@ public sealed class AiRemoteControlSystem : SharedAiRemoteControlSystem
             if (!ghostRole.ReregisterOnGhost || component.LifeStage > ComponentLifeStage.Running)
                 return;
 
+            Log.Error("Re-registering ghost role of parent AI");
             _ghostSystem.ReRegisterGhostRole(component.AiHolder.Value, ghostRole);
 
             component.AiHolder = null;

--- a/Content.Shared/Silicons/StationAi/SharedStationAiSystem.cs
+++ b/Content.Shared/Silicons/StationAi/SharedStationAiSystem.cs
@@ -107,6 +107,8 @@ public abstract partial class SharedStationAiSystem : EntitySystem
         SubscribeLocalEvent<StationAiCoreComponent, ComponentShutdown>(OnAiShutdown);
         SubscribeLocalEvent<StationAiCoreComponent, PowerChangedEvent>(OnCorePower);
         SubscribeLocalEvent<StationAiCoreComponent, GetVerbsEvent<Verb>>(OnCoreVerbs);
+
+        SubscribeLocalEvent<StationAiEyeComponent, ComponentShutdown>(OnComponentShutdown); // AS
     }
 
     private void OnCoreVerbs(Entity<StationAiCoreComponent> ent, ref GetVerbsEvent<Verb> args)
@@ -415,8 +417,9 @@ public abstract partial class SharedStationAiSystem : EntitySystem
         if (_net.IsClient)
             return false;
 
-        if (ent.Comp.RemoteEntity != null)
-            return false;
+        var comparison = new EntityUid(0); // TODO: Someone smarter than me come up with a more elegent solution
+        if (ent.Comp.RemoteEntity != null && ent.Comp.RemoteEntity != comparison) // AS: Its null or 0 if the eye gets deleted somehow. 
+            return false; // We don't want to set up an eye if it already exists
 
         var proto = ent.Comp.RemoteEntityProto;
 
@@ -428,7 +431,13 @@ public abstract partial class SharedStationAiSystem : EntitySystem
 
         if (proto != null)
         {
-            ent.Comp.RemoteEntity = SpawnAtPosition(proto, coords.Value);
+            var eye = SpawnAtPosition(proto, coords.Value); // AS
+            if (ent.Comp.Remote)
+            {
+                var eyeComp = EnsureComp<StationAiEyeComponent>(eye); // AS
+                eyeComp.CoreEntity = ent; // AS
+            }
+            ent.Comp.RemoteEntity = eye; // AS
             Dirty(ent);
         }
 
@@ -439,6 +448,9 @@ public abstract partial class SharedStationAiSystem : EntitySystem
     {
         if (_net.IsClient)
             return;
+
+        if (TryComp<StationAiEyeComponent>(ent.Comp.RemoteEntity, out var eye)) // AS: Null the eyes CoreEntity so it doesn't try to respawn itself when we delete it.
+            eye.CoreEntity = null;
 
         QueueDel(ent.Comp.RemoteEntity);
         ent.Comp.RemoteEntity = null;
@@ -578,6 +590,24 @@ public abstract partial class SharedStationAiSystem : EntitySystem
         }
 
         return _blocker.CanComplexInteract(entity.Owner);
+    }
+
+    private void OnComponentShutdown(EntityUid uid, StationAiEyeComponent component, ComponentShutdown args) // AS
+    {
+
+        var comparison = new EntityUid(0); // TODO: Someone smarter than me come up with a more elegent solution
+        if (component.CoreEntity == null || component.CoreEntity == comparison) // If its been nulled or zero, it either doesn't exist or been set that way purposefully.
+            return;
+
+        if (!TryComp<StationAiCoreComponent>(component.CoreEntity.Value, out var coreComp))
+            return;
+
+        var core = new Entity<StationAiCoreComponent>(component.CoreEntity.Value, coreComp);
+        coreComp.RemoteEntity = null; // Normally, RemoteEntity becomes 0 when it gets deleted, but this function fires in a wierd inbetween time
+        SetupEye(core); // So we set it to null here, so this function behaves as though the eye has been deleted.
+        AttachEye(core); // Which it will be, but hasn't yet. I'm not sure if this will cause issues.
+
+
     }
 }
 

--- a/Content.Shared/Silicons/StationAi/StationAiEyeComponent.cs
+++ b/Content.Shared/Silicons/StationAi/StationAiEyeComponent.cs
@@ -1,0 +1,20 @@
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.Silicons.StationAi;
+
+/// <summary>
+/// AS: Indicates this is the invisbile eye entity of a station AI core.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class StationAiEyeComponent : Component
+{
+
+    /// <summary>
+    /// The AI Core this belongs too.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public EntityUid? CoreEntity;
+
+
+}

--- a/Resources/Maps/_AS/Event/respite.yml
+++ b/Resources/Maps/_AS/Event/respite.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 267.4.0
   forkId: ""
   forkVersion: ""
-  time: 03/21/2026 21:54:16
-  entityCount: 792
+  time: 03/25/2026 00:40:42
+  entityCount: 793
 maps: []
 grids:
 - 1
@@ -369,6 +369,15 @@ entities:
     - type: Transform
       pos: -12.5,-9.5
       parent: 1
+- proto: AutonomousIDCard
+  entities:
+  - uid: 17
+    components:
+    - type: Transform
+      pos: 3.583571,-9.543048
+      parent: 1
+    - type: ShuttleDeed
+      shuttleUid: 1
 - proto: BlastDoor
   entities:
   - uid: 514
@@ -2785,15 +2794,6 @@ entities:
     - type: Transform
       pos: -12.5,-13.5
       parent: 1
-- proto: AutonomousIDCard
-  entities:
-  - uid: 17
-    components:
-    - type: Transform
-      pos: 3.583571,-9.543048
-      parent: 1
-    - type: ShuttleDeed
-      shuttleUid: 1
 - proto: Thruster
   entities:
   - uid: 47
@@ -4698,6 +4698,13 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 15.5,-17.5
+      parent: 1
+- proto: WarpPoint
+  entities:
+  - uid: 763
+    components:
+    - type: Transform
+      pos: 0.5,-5.5
       parent: 1
 - proto: WindoorSecurePlasma
   entities:


### PR DESCRIPTION
## About the PR
Fixes the accidental deletion of an AI eye causing the AI to be briked

Adds a warp point to the Respite

Properly fixes the ghost role system re-regestering an AI ghost role whenever it jumps into a borg

## Why / Balance
Fixes good

## Technical details
Adds a new component that tracks whether an entity is a floating AI Eye and a system that detects when said AI Eye gets deleted in order to respawn it

Moves a single line of code to set a value before putting a mind into a borg so  

## How to test
1. Load in a (ghost-rolled) AI core and a remote controllable borg
1.a. Delete your Eye, watch it respawn
2. Remote into said borg
3. Aghost and see how the ghost role isn't there

## Media
N/A

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes
N/A

**Changelog**
:cl:
- add: Added a warp point to the Respite
- fix: Fixed the deletion of an AI Eye bricking the AI
- fix: Fixed remote controlling a borg re-registering your core if you are a ghost role
