### PR TITLE
caramexinin half as effective as dylo

### DIFF
--- a/Resources/Prototypes/_NF/Reagents/medicine.yml
+++ b/Resources/Prototypes/_NF/Reagents/medicine.yml
@@ -62,4 +62,4 @@
       - !type:HealthChange
         damage:
           types:
-            Poison: -1
+            Poison: -0.1 # Aurora's Song - Half as effective as dylo


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Set Caramexinin's healing to 0.1 poison, overall unit to unit is half of dylo

## Why / Balance
Partial request, also delegates Caramexinin to be totally for theobromine poisoning instead of also poison damage.

## Technical details
Poison healing YML Change

## How to test
Drink Caramexinin

## Media
<img width="609" height="230" alt="image" src="https://github.com/user-attachments/assets/e6414ed3-ec94-4a8c-a3e4-42c4934f61c1" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
:cl:
tweak: lines up Caramexinin's healing to be half of dylo's per unit