### PR TITLE
Remove brightness limit on "Hues" skin tone

### DIFF
--- a/Content.Shared/Humanoid/SkinColor.cs
+++ b/Content.Shared/Humanoid/SkinColor.cs
@@ -9,7 +9,7 @@ public static class SkinColor
     public const float MaxTintedHuesSaturation = 0.1f;
     public const float MinTintedHuesLightness = 0.85f;
 
-    public const float MinHuesLightness = 0.175f;
+    public const float MinHuesLightness = 0.0f; // Aurora Song: 0.175f -> 0.0f
 
     public const float MinFeathersHue = 29f / 360;
     public const float MaxFeathersHue = 174f / 360;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
This PR reduces the minimum lightness value for the "Hues" skin tone from 17.5% to 0%, allowing players to make characters with pitch-black skin if they desired.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Markings already do not have this limitation - this change expands the level of customization of species with RGB slider skin tones.

Given that Aurora Song is a ship-based fork, I don't think this has very much impact on balance related to character visibility anyway. From my experience over at Den (which has a similar feature), people generally take this change in good faith

## Technical details
<!-- Summary of code changes for easier review. -->
Changed a C# float value

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
1. Create a character.
2. Change their species to one that uses `Hues` (e.g.: oni, feroxi, rodentia, vulpkanin, IPCs, tajaran, felinid, oni, arachnid, diona, moth, reptilian, slime, vox) or `HumanAnimal` skin tones (human, harpy, dwarf, fairy)
3. Attempt to change their skin tone to be darker than 17.5% lightness, e.g. pitch-black
4. You should be able to save the character as pitch-black

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="1553" height="444" alt="image" src="https://github.com/user-attachments/assets/31fc30b5-9d10-4c3c-b10c-784f375b0aad" />
<img width="1540" height="475" alt="image" src="https://github.com/user-attachments/assets/f78d02b4-9eb8-4eeb-b882-f174bdca8866" />
<img width="1522" height="447" alt="image" src="https://github.com/user-attachments/assets/b28ff475-9f72-4bda-84a0-b81cb5de67c0" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Species with HSV skin tones no longer have a minimum brightness limit on their skin.