### PR TITLE
Shipmind Tweaks/Balance

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -16,6 +16,8 @@
     - Security
     - Service
     - Supply
+    - Traffic # AS
+    - Shipboard # AS
   - type: ActiveRadio
     channels:
     - Binary
@@ -27,6 +29,8 @@
     - Security
     - Service
     - Supply
+    - Traffic # AS
+    - Shipboard # AS
   - type: IgnoreUIRange
   - type: StationAiHeld
   - type: StationAiOverlay

--- a/Resources/Prototypes/_AS/Entities/Mobs/Silicon/shipmind.yml
+++ b/Resources/Prototypes/_AS/Entities/Mobs/Silicon/shipmind.yml
@@ -47,6 +47,7 @@
     - Supply
     - Engineering
     - Medical
+    - Shipboard
   - type: IgnoreUIRange
   - type: StationAiHeld
   - type: StationAiOverlay
@@ -286,3 +287,6 @@
           - cell_slot
         - !type:DoActsBehavior
           acts: [ "Destruction" ]
+    - type: NpcFactionMember # Turns out not having a faction means you are friendly to everything
+      factions:
+      - NanoTrasen

--- a/Resources/Prototypes/_AS/Entities/Mobs/Silicon/shipmind.yml
+++ b/Resources/Prototypes/_AS/Entities/Mobs/Silicon/shipmind.yml
@@ -240,18 +240,7 @@
       blacklist:
         components:
         - RoboticsConsole # Lets them unlock other borgs
-    - type: NpcFactionMember # Below is things from its previous parenting of BaseBorgChassisSyndicate, minus antag icons, to make it not an ion storm target
-      factions:
-      - Syndicate
-    - type: Access
-      tags:
-      - NuclearOperative
-      - SyndicateAgent
-    - type: AccessReader
-      access: [["SyndicateAgent"], ["NuclearOperative"]]
-    - type: IntrinsicRadioTransmitter
-      channels:
-      - Binary
+ # Below is things from its previous parenting of BaseBorgChassisSyndicate, minus antag icons, to make it not an ion storm target
     - type: MovementAlwaysTouching
     - type: Speech
       speechSounds: SyndieBorg
@@ -265,3 +254,35 @@
       color: "#dd200b"
       radius: 8
     - type: Stripping # They have hands, let them put hats on their borgs. Or take things off people.
+    - type: MobThresholds
+      thresholds:
+        0: Alive
+        150: Critical # 50% chunkier than a standard borg
+        300: Dead
+    - type: Damageable
+      damageModifierSet: MobHostileDamageModifierSetHigh # And a smattering of light resists (I'm not sure why the modifier set is labeled 'high')
+    - type: Destructible
+      thresholds:
+      - trigger:
+          !type:DamageTrigger
+          damage: 100
+        behaviors:
+        - !type:PlaySoundBehavior
+          sound:
+            path: /Audio/Machines/warning_buzzer.ogg
+            params:
+              volume: 5
+      - trigger:
+          !type:DamageTrigger
+          damage: 450
+        behaviors:
+        - !type:PlaySoundBehavior
+          sound:
+            collection: MetalBreak
+        - !type:EmptyContainersBehaviour
+          containers:
+          - borg_brain
+          - borg_module
+          - cell_slot
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]


### PR DESCRIPTION
## About the PR
Made the shipmind a bit tankier in direct combat, and also removes a few thing left over that I forgot to remove

In the future, I want to add a more robust system for letting borgs increase their combat capability/survivability, but today isn't that day.

Also adds traffic and shipboard to base AI, and fixes it to work on shipmind AI

## Why / Balance
Compared to organics which are capable of wearing armour or taking chems, borgs are very very squishy. I've given it some armour and increased its health pool a bit.



## Technical details
YML Edits

## How to test
1. Get shot a few times

## Media
N/A

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes
N/A

**Changelog**
:cl:

- tweak: Increased the durability of Shipminds
- fix: Removed left over syndicate components from Shipminds
- fix: Shipboard and Shortband radios for all AI

