### PR TITLE
fix: formatting breaks on silicon and stutter accents

### DIFF
--- a/Content.Server/Speech/EntitySystems/DamagedSiliconAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/DamagedSiliconAccentSystem.cs
@@ -124,9 +124,19 @@ public sealed class DamagedSiliconAccentSystem : EntitySystem
         // Linear interpolation of character damage probability
         var damagePercent = Math.Clamp((float)totalDamage / (float)damageAtMaxCorruption, 0, 1);
         var chanceToCorruptLetter = damagePercent * ent.Comp.MaxDamageCorruption;
+        var disableCorruption = -1; // Aurora's Song - Support text formatting
         foreach (var letter in message)
         {
-            if (_random.Prob(chanceToCorruptLetter)) // Corrupt!
+            // Start Aurora's Song - Support text formatting
+            disableCorruption = letter switch
+            {
+                '\\' or ']' => 0,
+                '[' => 1,
+                _ => disableCorruption,
+            };
+
+            if (disableCorruption == -1  && _random.Prob(chanceToCorruptLetter)) // Corrupt!
+            // End Aurora's Song
             {
                 outMsg.Append(CorruptLetterDamage(letter));
             }
@@ -134,6 +144,9 @@ public sealed class DamagedSiliconAccentSystem : EntitySystem
             {
                 outMsg.Append(letter);
             }
+
+            if (disableCorruption == 0) // Aurora's Song - Support text formatting
+                disableCorruption = -1;
         }
         return outMsg.ToString();
     }
@@ -153,7 +166,7 @@ public sealed class DamagedSiliconAccentSystem : EntitySystem
 
     private string CorruptPunctuize()
     {
-        const string punctuation = "\"\\`~!@#$%^&*()_+-={}[]|\\;:<>,.?/";
+        const string punctuation = "\"`~!@#$%^&*()_+-={}]|;:<>,.?/"; // Aurora's Song - Remove characters which cause formatting issues
         return punctuation[_random.NextByte((byte)punctuation.Length)].ToString();
     }
 

--- a/Content.Server/Speech/EntitySystems/StutteringSystem.cs
+++ b/Content.Server/Speech/EntitySystems/StutteringSystem.cs
@@ -43,10 +43,21 @@ namespace Content.Server.Speech.EntitySystems
 
             string newLetter;
 
+            var disableAccentuate = -1; // Aurora's Song - Support text formatting
             for (var i = 0; i < length; i++)
             {
                 newLetter = message[i].ToString();
-                if (Stutter.IsMatch(newLetter) && _random.Prob(component.MatchRandomProb))
+
+                // Aurora's Song Start - Support text formatting
+                disableAccentuate = newLetter switch
+                {
+                    "\\" or "]" => 0,
+                    "[" => 1,
+                    _ => disableAccentuate,
+                };
+
+                if (disableAccentuate == -1 && Stutter.IsMatch(newLetter) && _random.Prob(component.MatchRandomProb))
+                // End Aurora's Song
                 {
                     if (_random.Prob(component.FourRandomProb))
                     {
@@ -65,6 +76,9 @@ namespace Content.Server.Speech.EntitySystems
                         newLetter = $"{newLetter}-{newLetter}";
                     }
                 }
+
+                if (disableAccentuate == 0) // Aurora's Song - Support text formatting
+                    disableAccentuate = -1;
 
                 finalMessage.Append(newLetter);
             }


### PR DESCRIPTION
<!-- IMPORTANT: Please make your title according to the specifications from https://www.conventionalcommits.org/en/v1.0.0/#summary -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
A really simple heuristic to ignore formatting on both silicon and stutter accents
Also makes the silicon one not end your sentence early

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Weird bugs that get accentuated by the denu

## Technical details
<!-- Summary of code changes for easier review. -->
- Ignores formatting in silicon and stuttering accents which use a foreach on the entire string to apply the accent
- Removes characters from IPC accent which will terminate or otherwise error your sentence

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
Go ingame as a silicon with the stutter accent
apply 99 blunt
try running ```say "god [italic][color=#FF13FF]wants[/color][/italic] me [bold]to[/bold] test [bolditalic]something[/bolditalic] really quick"```
in the console
if text output works, my code works

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="335" height="254" alt="image" src="https://github.com/user-attachments/assets/a35f38e6-dd16-4d09-b9cc-7243621b911e" />
<img width="500" height="249" alt="image" src="https://github.com/user-attachments/assets/7236db41-e281-410e-abc6-d4d2dc07d8fb" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Denu formatting no longer breaks players with the silicon damage accent, or the stuttering accent
- fix: The silicon damage accent will no longer terminate your sentences early
