### PR TITLE
fix: making avali carriable, adjusting 0g speed & thirst

### DIFF
--- a/Content.Shared/_Moffstation/Traits/Components/EmpVulnerableComponent.cs
+++ b/Content.Shared/_Moffstation/Traits/Components/EmpVulnerableComponent.cs
@@ -20,7 +20,7 @@ public sealed partial class EmpVulnerableComponent: Component
     /// Chance for entity to be disrupted by ion storm
     /// </summary>
     [DataField]
-    public float IonStunChance = 0.80f;
+    public float IonStunChance = 0.65f;
 
     ///<summary>
     /// Time the entity will be disrupted from an EMP

--- a/Resources/Prototypes/Reagents/botany.yml
+++ b/Resources/Prototypes/Reagents/botany.yml
@@ -215,7 +215,7 @@
     Food:
       effects:
       - !type:SatiateThirst
-        factor: 4
+        factor: 6
         conditions:
         - !type:OrganType
           type: Avali
@@ -316,7 +316,7 @@
     Drink:
       effects:
       - !type:SatiateThirst
-        factor: 2
+        factor: 3
         conditions:
         - !type:OrganType
           type: Avali

--- a/Resources/Prototypes/_CD/Entities/Mobs/Species/avali.yml
+++ b/Resources/Prototypes/_CD/Entities/Mobs/Species/avali.yml
@@ -9,12 +9,17 @@
     species: Avali
   - type: Hunger
   - type: Thirst
+  - type: MovementSpeedModifier # Aurora's Song - Added to put in line with other winged species speed in space.
+#    baseWalkSpeed: 2.5 # Frontier
+#    baseSprintSpeed: 5.0 # Frontier
+    weightlessAcceleration: 2.5
   - type: Icon
     sprite: _CD/Mobs/Species/Avali/parts.rsi
     state: full
   - type: Body
     prototype: Avali
     requiredLegs: 2
+  - type: Carriable
   - type: Butcherable
     butcheringType: Spike
     spawned:


### PR DESCRIPTION
<!-- IMPORTANT: Please make your title according to the specifications from https://www.conventionalcommits.org/en/v1.0.0/#summary -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added the carriable component, adjusted thirst factor, and 0g speed, and ION storm stun chance
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Why / Balance
Corrected the carriable component, brought Avali drinkable reagents to be more in line with saline's effects on humans, brought their 0g speed up to match harpies (wings), and adjusted their Ionstorm chance from 80 to 65 since it knocks you down and aurora is a more combat focused server.  
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
tweaked some C# YML
<!-- Summary of code changes for easier review. -->

## How to test
- Pull PR
- Drink Windex, jump into space, get picked up, and get ion stormed.
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: space movement speed to Avali
- tweak: Ionstorm stun chance, thirst factor of reagents. 
- fix: carriable component

