### PR TITLE
feat: Scrubbers filter helium by default

### DIFF
--- a/Content.Shared/Atmos/Piping/Unary/Components/SharedVentScrubberComponent.cs
+++ b/Content.Shared/Atmos/Piping/Unary/Components/SharedVentScrubberComponent.cs
@@ -24,7 +24,7 @@ namespace Content.Shared.Atmos.Piping.Unary.Components
             Gas.Ammonia,
             Gas.NitrousOxide,
             Gas.Frezon,
-            Gas.Helium //Aurora's Song - Scrub helium by default
+            Gas.Helium //Aurora's Song - Scrub helium by default, it alarms at <1% so it should be scrubbed by default.
         };
 
         // Presets for 'dumb' air alarm modes

--- a/Content.Shared/Atmos/Piping/Unary/Components/SharedVentScrubberComponent.cs
+++ b/Content.Shared/Atmos/Piping/Unary/Components/SharedVentScrubberComponent.cs
@@ -24,7 +24,7 @@ namespace Content.Shared.Atmos.Piping.Unary.Components
             Gas.Ammonia,
             Gas.NitrousOxide,
             Gas.Frezon,
-            Gas.Helium //AS - Scrub helium by default
+            Gas.Helium //Aurora's Song - Scrub helium by default
         };
 
         // Presets for 'dumb' air alarm modes

--- a/Content.Shared/Atmos/Piping/Unary/Components/SharedVentScrubberComponent.cs
+++ b/Content.Shared/Atmos/Piping/Unary/Components/SharedVentScrubberComponent.cs
@@ -23,7 +23,8 @@ namespace Content.Shared.Atmos.Piping.Unary.Components
             Gas.WaterVapor,
             Gas.Ammonia,
             Gas.NitrousOxide,
-            Gas.Frezon
+            Gas.Frezon,
+            Gas.Helium //AS - Scrub helium by default
         };
 
         // Presets for 'dumb' air alarm modes


### PR DESCRIPTION
<!-- IMPORTANT: Please make your title according to the specifications from https://www.conventionalcommits.org/en/v1.0.0/#summary -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Scrubbers now scrub helium by default

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
For a gas that causes a danger alarm at <1% concentration, it should probably be filtered out by default.

We had a huge helium leak on Damascus a few days ago, and it was a huge pain to clean up. The scrubbers were not picking it up automatically. If they were set to scrub helium, they would revert after a few seconds due to auto mode. Turning auto mode off is also really annoying because we'd have to configure every alarm twice.

## Technical details
<!-- Summary of code changes for easier review. -->
One C# line adding helium to the default scrubber filters.

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
Link any scrubber to an air alarm and see that helium is now selected by default

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="627" height="563" alt="image" src="https://github.com/user-attachments/assets/321e91ac-dce7-4ffc-9dbb-94044e0219d0" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Scrubbers now scrub helium by default.
