### PR TITLE
fix: Hotfix for SLE events being annoying

### DIFF
--- a/Content.Server/StationEvents/Components/StationEventComponent.cs
+++ b/Content.Server/StationEvents/Components/StationEventComponent.cs
@@ -165,4 +165,10 @@ public sealed partial class StationEventComponent : Component
     /// </summary>
     [DataField]
     public bool ArrivalAnnounced;
+
+    /// <summary>
+    ///     Aurora Song: What category, if any, this event belongs in.
+    /// </summary>
+    [DataField]
+    public string? Category;
 }

--- a/Content.Server/StationEvents/EventManagerSystem.cs
+++ b/Content.Server/StationEvents/EventManagerSystem.cs
@@ -11,6 +11,8 @@ using Content.Shared.EntityTable.EntitySelectors;
 using Content.Shared.EntityTable;
 using Content.Server.Mind; // Frontier
 using Content.Server._NF.Roles.Systems; // Frontier
+using Content.Server._AS.StationEvents.Components; // Aurora's Song
+using Content.Shared.Roles; // Aurora's Song
 
 namespace Content.Server.StationEvents;
 
@@ -293,7 +295,15 @@ public sealed class EventManagerSystem : EntitySystem
         {
             return false;
         }
-
+        if (stationEvent.Category != null) // Aurora's Song - Temporary fix to events firing when we don't want them too
+        {
+            var toggleQuery = AllEntityQuery<ToggleEventComponent>();
+            while (toggleQuery.MoveNext(out var uid, out var comp))
+            {
+                if (comp.Category == stationEvent.Category && comp.Active == false)
+                    return false;
+            }
+        }
         return true;
     }
 }

--- a/Content.Server/_AS/StationEvents/Components/ToggleEventComponent.cs
+++ b/Content.Server/_AS/StationEvents/Components/ToggleEventComponent.cs
@@ -1,0 +1,23 @@
+using Content.Server.StationEvents.Components;
+namespace Content.Server._AS.StationEvents.Components;
+
+/// <summary>
+/// Aurora Song - Bounty variant of New Frontier's BluespaceErrorRuleComponent
+/// Checks for specific mob prototypes and their cuff states for bonus rewards
+/// </summary>
+[RegisterComponent]
+public sealed partial class ToggleEventComponent : Component
+{
+    /// <summary>
+    /// Whether we allow events of the given category to fire. If false, the events will be prevented from triggering
+    /// </summary>
+    [DataField]
+    public bool Active = false;
+
+    /// <summary>
+    /// What category of events we want to prevent. The <seealso cref="StationEventComponent"/> needs a matching Category entry in order for this to function
+    /// </summary>
+    [DataField]
+    public string Category = "SLE";
+}
+

--- a/Content.Server/_AS/StationEvents/Systems/ToggleEventSystem.cs
+++ b/Content.Server/_AS/StationEvents/Systems/ToggleEventSystem.cs
@@ -1,0 +1,37 @@
+using Content.Server.StationEvents.Events;
+using Content.Server._AS.StationEvents.Components;
+using Content.Shared.Verbs;
+
+
+namespace Content.Server._AS.StationEvents.Systems
+{
+
+    public sealed class ToggleEventSystem : EntitySystem
+    {
+        public override void Initialize()
+        {
+            SubscribeLocalEvent<ToggleEventComponent, GetVerbsEvent<InteractionVerb>>(AddSearchVerb);
+        }
+
+        private void AddSearchVerb(EntityUid uid, ToggleEventComponent component, GetVerbsEvent<InteractionVerb> args)
+        {
+            if (!args.CanInteract || !args.CanAccess || args.Hands == null)
+                return;
+
+            //here we build our dynamic verb. Using the object's sprite for now to make it more dynamic for the moment.
+            InteractionVerb toggleVerb = new()
+            {
+                IconEntity = GetNetEntity(uid),
+                Act = () => ToggleState(component),
+                Text = component.Active ? Loc.GetString("verb-deactivate-text") : Loc.GetString("verb-activate-text"),
+                Priority = 3
+            };
+
+            args.Verbs.Add(toggleVerb);
+        }
+        private void ToggleState(ToggleEventComponent component)
+        {
+            component.Active = !component.Active;
+        }
+    }
+}

--- a/Resources/Locale/en-US/_AS/verbs/verbs.ftl
+++ b/Resources/Locale/en-US/_AS/verbs/verbs.ftl
@@ -1,0 +1,2 @@
+verb-deactivate-text = Deactivate
+verb-activate-text = Activate

--- a/Resources/Locale/en-US/_AS/verbs/verbs.ftl
+++ b/Resources/Locale/en-US/_AS/verbs/verbs.ftl
@@ -1,2 +1,2 @@
-verb-deactivate-text = Deactivate
-verb-activate-text = Activate
+verb-deactivate-text = Disable Events
+verb-activate-text = Enable Events

--- a/Resources/Prototypes/_AS/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/_AS/Entities/Structures/Machines/Computers/computers.yml
@@ -83,3 +83,5 @@
   - type: ContainerContainer
     containers:
       board: !type:Container
+  - type: ToggleEvent
+    active: false

--- a/Resources/Prototypes/_AS/Events/bluespace_bounty_events.yml
+++ b/Resources/Prototypes/_AS/Events/bluespace_bounty_events.yml
@@ -99,6 +99,7 @@
     reoccurrenceDelay: 240 # 4 hours
     requiredJobs:
       Sergeant: 1
+    category: SLE
   - type: BluespaceErrorBountyRule
     includeGridValue: false
     announcementChannels:
@@ -172,6 +173,7 @@
     reoccurrenceDelay: 120 # 2 hours
     requiredJobs:
       Sergeant: 1
+    category: SLE
   - type: BluespaceErrorBountyRule
     includeGridValue: false
     announcementChannels:

--- a/Resources/Prototypes/_NF/Events/nf_bluespace_grids_events.yml
+++ b/Resources/Prototypes/_NF/Events/nf_bluespace_grids_events.yml
@@ -1,135 +1,137 @@
-- type: entity
-  id: BluespaceCacheError
-  parent: BaseStationEventShortDelay
-  components:
-  - type: StationEvent
-    startAnnouncement: station-event-bluespace-cache-start-announcement
-    startAudio:
-      path: /Audio/Announcements/attention.ogg
-    warningAnnouncement: station-event-bluespace-cache-warning-announcement
-    endAnnouncement: station-event-bluespace-cache-end-announcement
-    earliestStart: 100
-    weight: 5
-    duration: 1350
-    maxDuration: 1560
-    reoccurrenceDelay: 360 # 6 hours
-    requiredJobs: # Aurora's Song - Switched to Commissioenr
-      Commissioner: 1
-  - type: BluespaceErrorRule
-    groups:
-      grid: !type:GridSpawnGroup
-        nameLoc:
-        - station-event-bluespace-name-SyndicateWeaponsCache
-        minimumDistance: 1500
-        maximumDistance: 2500
-        addComponents:
-        - type: Gravity
-          enabled: true
-          inherent: true
-        - type: IFF
-          color: "#E10F9B"
-        - type: Shuttle
-        - type: LinkedLifecycleGridParent
-        - type: ProtectedGrid
-          preventArtifactTriggers: true
-        - type: PreventPilot
-        - type: ForceAnchor # Added post-FTL, so anchoring is fine.
-        - type: DeletionCensusExempt
-        paths:
-        - /Maps/_NF/Bluespace/cache.yml
-    rewardAccounts:
-      Sle: 0.25 # Aurora Song - Changed from Nfsd to Sle (Sector Law Enforcement)
-      Aurora: 0.25 # Aurora Song - Changed from Frontier to Aurora
-      Medical: 0.25
-      Damascus: 0.25 # AS Edison -> Damascus
+# - type: entity # Start Aurora's Song - Commented out, unfun event
+#   id: BluespaceCacheError
+#   parent: BaseStationEventShortDelay
+#   components:
+#   - type: StationEvent
+#     startAnnouncement: station-event-bluespace-cache-start-announcement
+#     startAudio:
+#       path: /Audio/Announcements/attention.ogg
+#     warningAnnouncement: station-event-bluespace-cache-warning-announcement
+#     endAnnouncement: station-event-bluespace-cache-end-announcement
+#     earliestStart: 100
+#     weight: 5
+#     duration: 1350
+#     maxDuration: 1560
+#     reoccurrenceDelay: 360 # 6 hours
+#     requiredJobs: # Aurora's Song - Switched to Commissioenr
+#       Commissioner: 1
+#   - type: BluespaceErrorRule
+#     groups:
+#       grid: !type:GridSpawnGroup
+#         nameLoc:
+#         - station-event-bluespace-name-SyndicateWeaponsCache
+#         minimumDistance: 1500
+#         maximumDistance: 2500
+#         addComponents:
+#         - type: Gravity
+#           enabled: true
+#           inherent: true
+#         - type: IFF
+#           color: "#E10F9B"
+#         - type: Shuttle
+#         - type: LinkedLifecycleGridParent
+#         - type: ProtectedGrid
+#           preventArtifactTriggers: true
+#         - type: PreventPilot
+#         - type: ForceAnchor # Added post-FTL, so anchoring is fine.
+#         - type: DeletionCensusExempt
+#         paths:
+#         - /Maps/_NF/Bluespace/cache.yml
+#     rewardAccounts:
+#       Sle: 0.25 # Aurora Song - Changed from Nfsd to Sle (Sector Law Enforcement)
+#       Aurora: 0.25 # Aurora Song - Changed from Frontier to Aurora
+#       Medical: 0.25
+#       Damascus: 0.25 # AS Edison -> Damascus
 
-- type: entity
-  id: BluespaceVaultError
-  parent: BaseStationEventShortDelay
-  components:
-  - type: StationEvent
-    startAnnouncement: station-event-bluespace-vault-start-announcement
-    startAudio:
-      path: /Audio/Announcements/attention.ogg
-    warningAnnouncement: station-event-bluespace-vault-warning-announcement
-    endAnnouncement: station-event-bluespace-vault-end-announcement
-    earliestStart: 100
-    weight: 5
-    duration: 1020
-    maxDuration: 1350
-    reoccurrenceDelay: 360 # 6 hours
-    requiredJobs:
-      Commissioner: 1
-  - type: BluespaceErrorRule
-    groups:
-      grid: !type:GridSpawnGroup
-        nameLoc:
-        - station-event-bluespace-name-SecureNTVault
-        minimumDistance: 1500
-        maximumDistance: 2500
-        addComponents:
-        - type: Gravity
-          enabled: true
-          inherent: true
-        - type: IFF
-          color: "#E10F9B"
-        - type: LinkedLifecycleGridParent
-        - type: ProtectedGrid
-          preventArtifactTriggers: true
-        - type: PreventPilot
-        - type: ForceAnchor
-        - type: DeletionCensusExempt
-        paths:
-        - /Maps/_NF/Bluespace/vault.yml
-    rewardAccounts:
-      Sle: 0.25 # Aurora Song - Changed from Nfsd to Sle (Sector Law Enforcement)
-      Aurora: 0.25 # Aurora Song - Changed from Frontier to Aurora
-      Medical: 0.25
-      Damascus: 0.25 # AS Edison -> Damascus
-- type: entity
-  id: BluespaceVaultSmallError
-  parent: BaseStationEventShortDelay
-  components:
-  - type: StationEvent
-    startAnnouncement: station-event-bluespace-vault-start-announcement
-    startAudio:
-      path: /Audio/Announcements/attention.ogg
-    warningAnnouncement: station-event-bluespace-vault-warning-announcement
-    endAnnouncement: station-event-bluespace-vault-end-announcement
-    earliestStart: 100
-    maximumPlayers: 30
-    weight: 5
-    duration: 590
-    maxDuration: 780
-    reoccurrenceDelay: 360 # 6 hours
-    requiredJobs: # Aurora's Song - Switched Sheriff to Commissioner
-      Commissioner: 1
-  - type: BluespaceErrorRule
-    groups:
-      grid: !type:GridSpawnGroup
-        nameLoc:
-        - station-event-bluespace-name-SecureNTVault
-        minimumDistance: 1500
-        maximumDistance: 2500
-        addComponents:
-        - type: Gravity
-          enabled: true
-          inherent: true
-        - type: IFF
-          color: "#E10F9B"
-        - type: LinkedLifecycleGridParent
-        - type: ProtectedGrid
-          preventArtifactTriggers: true
-        - type: PreventPilot
-        - type: ForceAnchor
-        - type: DeletionCensusExempt
-        paths:
-        - /Maps/_NF/Bluespace/vaultsmall.yml
-    rewardAccounts:
-      Sle: 0.25 # Aurora Song - Changed from Nfsd to Sle (Sector Law Enforcement)
-      Aurora: 0.25 # Aurora Song - Changed from Frontier to Aurora
-      Medical: 0.25
-      Damascus: 0.25 # AS Edison -> Damascus
+# - type: entity
+#   id: BluespaceVaultError
+#   parent: BaseStationEventShortDelay
+#   components:
+#   - type: StationEvent
+#     startAnnouncement: station-event-bluespace-vault-start-announcement
+#     startAudio:
+#       path: /Audio/Announcements/attention.ogg
+#     warningAnnouncement: station-event-bluespace-vault-warning-announcement
+#     endAnnouncement: station-event-bluespace-vault-end-announcement
+#     earliestStart: 100
+#     weight: 5
+#     duration: 1020
+#     maxDuration: 1350
+#     reoccurrenceDelay: 360 # 6 hours
+#     requiredJobs:
+#       Commissioner: 1
+#   - type: BluespaceErrorRule
+#     groups:
+#       grid: !type:GridSpawnGroup
+#         nameLoc:
+#         - station-event-bluespace-name-SecureNTVault
+#         minimumDistance: 1500
+#         maximumDistance: 2500
+#         addComponents:
+#         - type: Gravity
+#           enabled: true
+#           inherent: true
+#         - type: IFF
+#           color: "#E10F9B"
+#         - type: LinkedLifecycleGridParent
+#         - type: ProtectedGrid
+#           preventArtifactTriggers: true
+#         - type: PreventPilot
+#         - type: ForceAnchor
+#         - type: DeletionCensusExempt
+#         paths:
+#         - /Maps/_NF/Bluespace/vault.yml
+#     rewardAccounts:
+#       Sle: 0.25 # Aurora Song - Changed from Nfsd to Sle (Sector Law Enforcement)
+#       Aurora: 0.25 # Aurora Song - Changed from Frontier to Aurora
+#       Medical: 0.25
+#       Damascus: 0.25 # AS Edison -> Damascus
+
+# - type: entity
+#   id: BluespaceVaultSmallError
+#   parent: BaseStationEventShortDelay
+#   components:
+#   - type: StationEvent
+#     startAnnouncement: station-event-bluespace-vault-start-announcement
+#     startAudio:
+#       path: /Audio/Announcements/attention.ogg
+#     warningAnnouncement: station-event-bluespace-vault-warning-announcement
+#     endAnnouncement: station-event-bluespace-vault-end-announcement
+#     earliestStart: 100
+#     maximumPlayers: 30
+#     weight: 5
+#     duration: 590
+#     maxDuration: 780
+#     reoccurrenceDelay: 360 # 6 hours
+#     requiredJobs: # Aurora's Song - Switched Sheriff to Commissioner
+#       Commissioner: 1
+#   - type: BluespaceErrorRule
+#     groups:
+#       grid: !type:GridSpawnGroup
+#         nameLoc:
+#         - station-event-bluespace-name-SecureNTVault
+#         minimumDistance: 1500
+#         maximumDistance: 2500
+#         addComponents:
+#         - type: Gravity
+#           enabled: true
+#           inherent: true
+#         - type: IFF
+#           color: "#E10F9B"
+#         - type: LinkedLifecycleGridParent
+#         - type: ProtectedGrid
+#           preventArtifactTriggers: true
+#         - type: PreventPilot
+#         - type: ForceAnchor
+#         - type: DeletionCensusExempt
+#         paths:
+#         - /Maps/_NF/Bluespace/vaultsmall.yml
+#     rewardAccounts:
+#       Sle: 0.25 # Aurora Song - Changed from Nfsd to Sle (Sector Law Enforcement)
+#       Aurora: 0.25 # Aurora Song - Changed from Frontier to Aurora
+#       Medical: 0.25
+#       Damascus: 0.25 # AS Edison -> Damascus # End Aurora's Song
+
 - type: entity
   id: BluespaceSyndicateFTLInterception
   parent: BaseStationEventShortDelay


### PR DESCRIPTION
## About the PR
Adds a verb to the SCU output terminal that can toggle a boolean to enable or disable the triggering of events.

These events fire even if no SLE are on, so if you turn it on, make sure to turn it off before you cryo. (It defaults to off)

## Why / Balance
Many many times have SLE been swamped by things going on and then an event fires that they are semi-obligated to do, or Sergeant players turned away because signing on means dealing with events. No more, now its optional

## Technical details
Adds the "Category" tag to StationEventComponent, the event scheduler looks for a entity with a ToggleEventComponent and a matching category, and if the component is set to inactive, the even isn't valid for the scheduler.

## How to test
1. Load in as SLE
2. Go the output room
3. Flick it on
4. Get accosted with 20 events

## Media
N/A

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes
N/A

**Changelog**
:cl:
- add: Added a toggle to the SCU Output Terminal to enable or disable SLE events

