### PR TITLE
fix: Fix Final ESS Failsafe never triggering.

### DIFF
--- a/Content.Server/Salvage/SalvageSystem.Expeditions.cs
+++ b/Content.Server/Salvage/SalvageSystem.Expeditions.cs
@@ -300,6 +300,22 @@ public sealed partial class SalvageSystem
     // Send all ghosts (relevant for admins) back to the default map so they don't lose their stuff.
     private void OnMapTerminating(EntityUid uid, SalvageExpeditionComponent component, EntityTerminatingEvent ev)
     {
+        FindPlayers(uid, null, out var players); // Begin Aurora's Song | If there is somehow still players on the map when its being deleted throw them into space.
+        if (players.Count > 0)
+        {
+            foreach (var entity in players)
+            {
+                Log.Debug($"Trying to warp {entity}");
+                if (!_mapSystem.TryGetMap(_gameTicker.DefaultMap, out var mapUid))
+                {
+                    Log.Error($"Could not get DefaultMap EntityUID, entity {entity} may be deleted.");
+                    break;
+                }
+                var fallback = new EntityCoordinates(mapUid.Value, _random.NextVector2(2000f, 2000f));
+                SafetyWarp(entity, fallback);
+            }
+        } // End Aurora's Song
+
         var ghosts = EntityQueryEnumerator<GhostComponent, TransformComponent>();
         var newCoords = new MapCoordinates(Vector2.Zero, _gameTicker.DefaultMap);
         while (ghosts.MoveNext(out var ghostUid, out _, out var xform))

--- a/Content.Server/Salvage/SalvageSystem.Runner.cs
+++ b/Content.Server/Salvage/SalvageSystem.Runner.cs
@@ -349,24 +349,7 @@ public sealed partial class SalvageSystem
             } // End Aurora's Song
 
             if (remaining < TimeSpan.Zero)
-            {
-                FindPlayers(uid, null, out var players); // Begin Aurora's Song
-                if (players.Count > 0)
-                {
-                    foreach (var entity in players)
-                    {
-                        Log.Debug($"Trying to warp {entity}");
-                        if (!_mapSystem.TryGetMap(_gameTicker.DefaultMap, out var mapUid))
-                        {
-                            Log.Error($"Could not get DefaultMap EntityUID, entity {entity} may be deleted.");
-                            break;
-                        }
-                        var fallback = new EntityCoordinates(mapUid.Value, _random.NextVector2(2000f, 2000f));
-                        SafetyWarp(entity, fallback);
-                    }
-                } // End Aurora's Song
                 QueueDel(uid);
-            }
         }
 
         // Frontier: mission-specific logic


### PR DESCRIPTION
<!-- IMPORTANT: Please make your title according to the specifications from https://www.conventionalcommits.org/en/v1.0.0/#summary -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Makes the final ESS failsafe trigger on map deletion instead of it being based on time.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Turns out the map gets deleted a couple hundred milliseconds before the remaining time reaches zero so the if statement never gets triggered. (Consistently reproduced in testing)

## Technical details
<!-- Summary of code changes for easier review. -->
Simply moves lines 352 - 367 from the SalvageSystem.Runner to the SalvageSystem.Expeditions OnMapTerminating function. It sits right above the same code that makes ghosts appear at the center of the PB when their character gets deleted so I'm confident it will trigger consistently.

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
1. Comment out lines 320 - 349 (as of this PR). 
2. Go in game and get into a expedition.
3. Die badly.
4. Get thrown into space instead of getting deleted.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Oberonics
- fix: Your character should (HOPEFULLY) no longer get deleted by a ESS failure and instead get throw into the depths of space if all else fails.

