### PR TITLE
feat: Changes ghost hearing to default to local and radio only

### DIFF
--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -132,12 +132,12 @@ namespace Content.Server.Ghost
             if (HasComp<GhostHearingComponent>(uid))
             {
                 RemComp<GhostHearingComponent>(uid);
-                _actions.SetToggled(component.ToggleGhostHearingActionEntity, true);
+                _actions.SetToggled(component.ToggleGhostHearingActionEntity, false); // Aurora Song: true > false
             }
             else
             {
                 AddComp<GhostHearingComponent>(uid);
-                _actions.SetToggled(component.ToggleGhostHearingActionEntity, false);
+                _actions.SetToggled(component.ToggleGhostHearingActionEntity, true);// Aurora Song: false > true
             }
 
             var str = HasComp<GhostHearingComponent>(uid)

--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -137,7 +137,7 @@ namespace Content.Server.Ghost
             else
             {
                 AddComp<GhostHearingComponent>(uid);
-                _actions.SetToggled(component.ToggleGhostHearingActionEntity, true);// Aurora Song: false > true
+                _actions.SetToggled(component.ToggleGhostHearingActionEntity, true); // Aurora Song: false > true
             }
 
             var str = HasComp<GhostHearingComponent>(uid)

--- a/Resources/Locale/en-US/ghost/ghost-gui.ftl
+++ b/Resources/Locale/en-US/ghost/ghost-gui.ftl
@@ -10,7 +10,7 @@ ghost-gui-toggle-fov-popup = Toggled field-of-view.
 ghost-gui-respawn = Respawn
 ghost-gui-uncryo = Un-cryo
 
-ghost-gui-toggle-hearing-popup-on = You can now hear all messages.
+ghost-gui-toggle-hearing-popup-on = You can now hear all messages. User discretion is advised.
 ghost-gui-toggle-hearing-popup-off = You can now only hear radio and nearby messages.
 
 ghost-target-window-title = Ghost Warp

--- a/Resources/Prototypes/Entities/Mobs/Player/observer.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/observer.yml
@@ -54,7 +54,7 @@
   - type: Examiner
     skipChecks: true
   - type: Ghost
-  # - type: GhostHearing # Aurora's Song commented out
+  # - type: GhostHearing # Aurora's Song commented out to make the default ghost hearing be local only
   - type: ShowElectrocutionHUD
   - type: IntrinsicRadioReceiver
   - type: ActiveRadio

--- a/Resources/Prototypes/Entities/Mobs/Player/observer.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/observer.yml
@@ -54,7 +54,7 @@
   - type: Examiner
     skipChecks: true
   - type: Ghost
-  # - type: GhostHearing # Aurora's Song commented out to make the default ghost hearing be local only
+  # - type: GhostHearing # Aurora Song commented out to make the default ghost hearing be local only
   - type: ShowElectrocutionHUD
   - type: IntrinsicRadioReceiver
   - type: ActiveRadio

--- a/Resources/Prototypes/Entities/Mobs/Player/observer.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/observer.yml
@@ -54,7 +54,7 @@
   - type: Examiner
     skipChecks: true
   - type: Ghost
-  - type: GhostHearing
+  # - type: GhostHearing # Aurora's Song commented out
   - type: ShowElectrocutionHUD
   - type: IntrinsicRadioReceiver
   - type: ActiveRadio
@@ -162,9 +162,9 @@
   description: Toggle between hearing all messages and hearing only radio & nearby messages.
   components:
   - type: Action
-    icon:
+    icon: Interface/Actions/ghostHearingToggled.png # Aurora Song: Flipped icon states
+    iconOn:
       sprite: Clothing/Ears/Headsets/base.rsi
       state: icon
-    iconOn: Interface/Actions/ghostHearingToggled.png
   - type: InstantAction
     event: !type:ToggleGhostHearingActionEvent


### PR DESCRIPTION
<!-- IMPORTANT: Please make your title according to the specifications from https://www.conventionalcommits.org/en/v1.0.0/#summary -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Ghost hearing now starts as local and radio only to set the standard that you should only turn on all hearing if you are willing to see what some might be saying.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Many players are running clubs or otherwise large adult events and sticking to just whispers for content that may be explicit but not incredibly lewd is not always feasible. The main reason to tell players to watch what they say is out of fear that ghosts may hear them. I think we should just expect ghosts to only listen to every chat if they're willing to potentially see something adult themed. This change however, does NOT give players the go ahead to say extremely NSFW remarks without whispering. A decent way to think about it is that in our NSFW channels on discord you are expected to content warning and spoiler things that may cross a line, but you are allowed to make suggestive statements.

## Technical details
<!-- Summary of code changes for easier review. -->
Switched a toggle in the ghost system and edited some yaml

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
/ghost
see that the headset is defaulted to off

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="725" height="483" alt="image" src="https://github.com/user-attachments/assets/8698d804-4868-4c86-8953-2032382685df" />
<img width="795" height="225" alt="image" src="https://github.com/user-attachments/assets/ac000864-ecc5-4c7b-83a8-61e3fb45afc6" />
<img width="781" height="226" alt="image" src="https://github.com/user-attachments/assets/d943b23a-4157-4b4a-8070-8a0ccf5e7b33" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: ghost hearing defaults to off