### PR TITLE
fix: Stop Unintended FTL Implant Triggering

### DIFF
--- a/Content.Server/Explosion/EntitySystems/TriggerSystem.Mobstate.cs
+++ b/Content.Server/Explosion/EntitySystems/TriggerSystem.Mobstate.cs
@@ -136,6 +136,12 @@ public sealed partial class TriggerSystem
         TriggerOnMobstateChangeComponent component,
         ImplantRelayEvent<ReTriggerRattleImplantEvent> args)
     {
+        // TODO: move this out of MobState after Trigger Refactor
+        // Coyote Bandaid fix moved here | Aurora
+        if (!TryComp<MobStateComponent>(args.Event.Implanted, out var mobstate)
+            || mobstate.CurrentState == MobState.Alive)
+            return;
+
         TryRunTrigger(
             uid,
             component,

--- a/Content.Server/Explosion/EntitySystems/TriggerSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/TriggerSystem.cs
@@ -272,11 +272,10 @@ namespace Content.Server.Explosion.EntitySystems
 
             if (implanted.ImplantedEntity == null)
                 return;
-            // Coyote
-            if (!TryComp<MobStateComponent>(implanted.ImplantedEntity, out var mobstate)
-                || mobstate.CurrentState == MobState.Alive)
-                return;
 
+            // Coyote
+            if (!TryComp<MobStateComponent>(implanted.ImplantedEntity, out var mobstate))
+                return;
 
             // Gets location of the implant
             var ownerXform = Transform(uid);


### PR DESCRIPTION
<!-- IMPORTANT: Please make your title according to the specifications from https://www.conventionalcommits.org/en/v1.0.0/#summary -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Moved a mobstate check out of HandleRattleTrigger to OnFtlArriveRelay to prevent mobstate implants like death acidifier and sad trombone from activating unintentionally.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
OnFtlArriveRelay is intended to reactive death rattles for cases like when you go down in a expedition. Coyote added a mobstate check in the HandleRattleTrigger function but didn't account for other implants, this fixes that.

## Technical details
<!-- Summary of code changes for easier review. -->
Simply moves the check, works based on testing. Keeps the TryComp in the HandleRattleTrigger since it is needed for other things in the function.

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
1. Get on a ship and implant a death acidifier.
2. FTL somewhere.
3. Don't get gooped upon arrival.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**

:cl: Oberonics
- fix: Implants will no longer activate in a unintended way when you finish FTLing.

