### PR TITLE
fix: Revert frontiermos trit ignition point to upstream value

### DIFF
--- a/Resources/Prototypes/Atmospherics/reactions.yml
+++ b/Resources/Prototypes/Atmospherics/reactions.yml
@@ -11,7 +11,7 @@
 - type: gasReaction
   id: TritiumFire
   priority: -1
-  minimumTemperature: 700 # Frontier: 373.149<700 - hot for a plasma fire
+  minimumTemperature: 373.149 # Same as Atmospherics.FireMinimumTemperatureToExist
   minimumRequirements: # In this case, same as minimum mole count.
     Oxygen: 0.01
     Tritium: 0.01


### PR DESCRIPTION
<!-- IMPORTANT: Please make your title according to the specifications from https://www.conventionalcommits.org/en/v1.0.0/#summary -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Discussion: https://discord.com/channels/1374826764169117827/1498428329655668878/1498428329655668878
This is the first (and maybe last?) part of fixing trit burns.
The first issue is frontier's increased ignition point for trit, causing it to not light in some plasma fires. Notably, a max pressure burn in Damascus's TEG chamber would leave unburned trit, and has to be reignited manually. This PR allows the plasma burn itself to light and consume the trit.

Secondly, and not in scope of this PR, the new conservation of energy math greatly reduces the heat energy produced by trit. More discussion needed on whether and how to fix this!

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Allows plasma burns to behave like on stations. The upmerge's trit math fix compounds with this frontiermos change in a really sucky way.

## Technical details
<!-- Summary of code changes for easier review. -->
One line yaml. I removed the Frontier comment and **restored the wizden comment**. I can add an AS comment, but since we are downstream of wizden, it seems appropriate to just revert it to that.

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
Make a plasma fire and see that the trit is consumed much sooner. 

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
- [x] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Trit ignites at the normal temperature (revert frontiermos value)