### PR TITLE
fix: Make gold, silver, and ore item stacks congruous with other mats

### DIFF
--- a/Resources/Prototypes/Stacks/ore.yml
+++ b/Resources/Prototypes/Stacks/ore.yml
@@ -1,70 +1,70 @@
 # unrefined ore
 
 - type: stack
-  parent: BaseMediumStack
+  parent: BaseVeryLargeStack # Aurora's Song BaseMediumStack>BaseVeryLargeStack
   id: GoldOre
   name: stack-gold-ore
   icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: gold }
   spawn: GoldOre1
 
 - type: stack
-  parent: BaseMediumStack
+  parent: BaseVeryLargeStack # Aurora's Song BaseMediumStack>BaseVeryLargeStack
   id: DiamondOre
   name: stack-rough-diamond
   icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: diamond }
   spawn: DiamondOre1
 
 - type: stack
-  parent: BaseMediumStack
+  parent: BaseVeryLargeStack # Aurora's Song BaseMediumStack>BaseVeryLargeStack
   id: SteelOre
   name: stack-iron-ore
   icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: iron }
   spawn: SteelOre1
 
 - type: stack
-  parent: BaseMediumStack
+  parent: BaseVeryLargeStack # Aurora's Song BaseMediumStack>BaseVeryLargeStack
   id: PlasmaOre
   name: stack-plasma-ore
   icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: plasma }
   spawn: PlasmaOre1
 
 - type: stack
-  parent: BaseMediumStack
+  parent: BaseVeryLargeStack # Aurora's Song BaseMediumStack>BaseVeryLargeStack
   id: SilverOre
   name: stack-silver-ore
   icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: silver }
   spawn: SilverOre1
 
 - type: stack
-  parent: BaseMediumStack
+  parent: BaseVeryLargeStack # Aurora's Song BaseMediumStack>BaseVeryLargeStack
   id: SpaceQuartz
   name: stack-space-quartz
   icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: spacequartz }
   spawn: SpaceQuartz1
 
 - type: stack
-  parent: BaseMediumStack
+  parent: BaseVeryLargeStack # Aurora's Song BaseMediumStack>BaseVeryLargeStack
   id: UraniumOre
   name: stack-uranium-ore
   icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: uranium }
   spawn: UraniumOre1
 
 - type: stack
-  parent: BaseMediumStack
+  parent: BaseVeryLargeStack # Aurora's Song BaseMediumStack>BaseVeryLargeStack
   id: BananiumOre
   name: stack-bananium-ore
   icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: bananium }
   spawn: BananiumOre1
 
 - type: stack
-  parent: BaseMediumStack
+  parent: BaseVeryLargeStack # Aurora's Song BaseMediumStack>BaseVeryLargeStack
   id: Coal
   name: stack-coal
   icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: coal }
   spawn: Coal1
 
 - type: stack
-  parent: BaseMediumStack
+  parent: BaseVeryLargeStack # Aurora's Song BaseMediumStack>BaseVeryLargeStack
   id: SaltOre
   name: stack-salt
   icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: salt }

--- a/Resources/Prototypes/Stacks/ore_refined.yml
+++ b/Resources/Prototypes/Stacks/ore_refined.yml
@@ -16,14 +16,14 @@
 
 # Ingots
 - type: stack
-  parent: BaseMediumStack
+  parent: BaseVeryLargeStack # Aurora's Song BaseMediumStack>BaseVeryLargeStack
   id: Gold
   name: stack-gold
   icon: { sprite: "/Textures/Objects/Materials/ingots.rsi", state: gold }
   spawn: IngotGold1
 
 - type: stack
-  parent: BaseMediumStack
+  parent: BaseVeryLargeStack # Aurora's Song BaseMediumStack>BaseVeryLargeStack
   id: Silver
   name: stack-silver
   icon: { sprite: "/Textures/Objects/Materials/ingots.rsi", state: silver }


### PR DESCRIPTION
<!-- IMPORTANT: Please make your title according to the specifications from https://www.conventionalcommits.org/en/v1.0.0/#summary -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Parents gold ingots, silver ingots, and most ores (except bluespace) to the maximum stack size entity, like the rest of the basic materials.

## Why / Balance
Changed by upmerge, and it's really inconvenient to carry them now!

## Technical details
All yml, two files.

## How to test
Open the game, spawn in a couple [Full] stacks of gold, silver, or ore, and stack them up to 120.

## Media
<img width="510" height="159" alt="image" src="https://github.com/user-attachments/assets/bcc726c3-73bd-4abf-9398-d72e7afe42ac" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
:cl:
- fix: Gold, silver, and ores should now stack just as neatly as the rest of their fellows.
