### PR TITLE
fix: Replicant Blood Volume

### DIFF
--- a/Content.Shared/_AS/Traits/ReplicantComponent.cs
+++ b/Content.Shared/_AS/Traits/ReplicantComponent.cs
@@ -1,3 +1,5 @@
+
+using Content.Shared.Chemistry.Components; // VDS
 using Robust.Shared.GameStates;
 
 namespace Content.Shared._AS.Traits;
@@ -9,4 +11,9 @@ namespace Content.Shared._AS.Traits;
 [RegisterComponent, NetworkedComponent, Access(typeof(ReplicantSystem))]
 public sealed partial class ReplicantComponent : Component
 {
+    /// <summary>
+    /// VDS - The reagent that replaces the synth's blood
+    /// </summary>
+    [DataField]
+    public Solution OxidantReagent = new([new("Oxidant", 300)]);
 }

--- a/Content.Shared/_AS/Traits/ReplicantSystem.cs
+++ b/Content.Shared/_AS/Traits/ReplicantSystem.cs
@@ -8,7 +8,7 @@ namespace Content.Shared._AS.Traits;
 public sealed class ReplicantSystem : EntitySystem
 {
     private static readonly ProtoId<TypingIndicatorPrototype> TypingIndicator = "robot";
-    private static readonly ProtoId<ReagentPrototype> Blood = "Oxidant";
+//    private static readonly ProtoId<ReagentPrototype> Blood = "Oxidant"; // VDS - use solution in component instead.
 
     [Dependency] private readonly SharedBloodstreamSystem _bloodSystem = default!;
     [Dependency] private readonly SharedTypingIndicatorSystem _typingIndicator = default!;
@@ -22,6 +22,6 @@ public sealed class ReplicantSystem : EntitySystem
     private void OnReplicantStartup(EntityUid uid, ReplicantComponent component, ComponentStartup args)
     {
         _typingIndicator.SetTypingIndicator(uid, TypingIndicator);
-        _bloodSystem.ChangeBloodReagent(uid, Blood);
+        _bloodSystem.ChangeBloodReagents(uid, component.OxidantReagent); // VDS - update to use new ChangeBloodReagents
     }
 }


### PR DESCRIPTION
<!-- IMPORTANT: Please make your title according to the specifications from https://www.conventionalcommits.org/en/v1.0.0/#summary -->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Port of the fix for synth/replicant blood volume from Vermist Dust[ #83](https://github.com/vermist-sector/vermist-dust/pull/83).

## Why / Balance
Brings characters with the replicant trait back in line with non-replicant characters, with a full 300u of blood.

## Technical details
Small C# tweaks.

## How to test
Create a character with the Replicant trait, then check their solutions to make sure they have 300u of Oxidant in them instead of 1.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
:cl:
- fix: Replicants are no longer expected to survive on a measly single unit of oxidant.
